### PR TITLE
Bugfix `compose_sequentially`

### DIFF
--- a/graphix_zx/graphstate.py
+++ b/graphix_zx/graphstate.py
@@ -687,13 +687,15 @@ def compose_sequentially(  # noqa: C901
         2. If the logical qubit indices of output nodes in graph1 do not match input nodes in graph2.
     """
     if not graph1.is_canonical_form():
-        raise ValueError("graph1 must be in canonical form.")
+        msg = "graph1 must be in canonical form."
+        raise ValueError(msg)
     if not graph2.is_canonical_form():
-        raise ValueError("graph2 must be in canonical form.")
+        msg = "graph2 must be in canonical form."
+        raise ValueError(msg)
     if set(graph1.output_node_indices.values()) != set(graph2.input_node_indices.values()):
-        raise ValueError(
-            "Logical qubit indices of output nodes in graph1 must match input nodes in graph2."
-        )
+        msg = "Logical qubit indices of output nodes in graph1 must match input nodes in graph2."
+        raise ValueError(msg)
+
     node_map1: dict[int, int] = {}
     node_map2: dict[int, int] = {}
     composed_graph = GraphState()
@@ -722,7 +724,7 @@ def compose_sequentially(  # noqa: C901
     for input_node_index2, q_index in graph2.input_node_indices.items():
         node_map1[q_index2output_node_index1[q_index]] = node_map2[input_node_index2]
 
-    #　register inputs/outputs
+    # register inputs/outputs
     for input_node, _ in sorted(graph1.input_node_indices.items(), key=operator.itemgetter(1)):
         composed_graph.register_input(node_map1[input_node])
 
@@ -733,7 +735,7 @@ def compose_sequentially(  # noqa: C901
     def _add_edge_safe(g: BaseGraphState, a: int, b: int) -> None:
         if a == b:
             return
-        if not a in g.neighbors(b):
+        if a not in g.neighbors(b):
             g.add_physical_edge(a, b)
 
     for u, v in graph1.physical_edges:

--- a/graphix_zx/graphstate.py
+++ b/graphix_zx/graphstate.py
@@ -728,18 +728,13 @@ def compose_sequentially(  # noqa: C901
 
     for output_node, q_index in graph2.output_node_indices.items():
         composed_graph.register_output(node_map2[output_node], q_index)
-        
+
     # add edges (skip duplicates safely)
     def _add_edge_safe(g: BaseGraphState, a: int, b: int) -> None:
         if a == b:
             return
-        try:
+        if not a in g.neighbors(b):
             g.add_physical_edge(a, b)
-        except ValueError as e:
-            # Ignore exact-duplicate edges introduced by the overlap
-            if "Edge already exists" in str(e):
-                return
-            raise
 
     for u, v in graph1.physical_edges:
         _add_edge_safe(composed_graph, node_map1[u], node_map1[v])

--- a/graphix_zx/graphstate.py
+++ b/graphix_zx/graphstate.py
@@ -663,7 +663,7 @@ class ExpansionMaps(NamedTuple):
     output_node_map: dict[int, LocalCliffordExpansion]
 
 
-def compose_sequentially(  # noqa: C901
+def compose_sequentially(
     graph1: BaseGraphState, graph2: BaseGraphState
 ) -> tuple[BaseGraphState, dict[int, int], dict[int, int]]:
     r"""Compose two graph states sequentially.
@@ -701,7 +701,7 @@ def compose_sequentially(  # noqa: C901
     node_map1 = _copy_nodes(
         src=graph1,
         dst=composed_graph,
-        exclude_nodes=set(graph1.output_node_indices.keys()),
+        exclude_nodes=graph1.output_node_indices,
     )
     node_map2 = _copy_nodes(
         src=graph2,
@@ -722,11 +722,9 @@ def compose_sequentially(  # noqa: C901
         composed_graph.register_output(node_map2[output_node], q_index)
 
     for u, v in graph1.physical_edges:
-        if node_map1[u] not in composed_graph.neighbors(node_map1[v]):
-            composed_graph.add_physical_edge(node_map1[u], node_map1[v])
+        composed_graph.add_physical_edge(node_map1[u], node_map1[v])
     for u, v in graph2.physical_edges:
-        if node_map2[u] not in composed_graph.neighbors(node_map2[v]):
-            composed_graph.add_physical_edge(node_map2[u], node_map2[v])
+        composed_graph.add_physical_edge(node_map2[u], node_map2[v])
 
     return composed_graph, node_map1, node_map2
 
@@ -734,7 +732,7 @@ def compose_sequentially(  # noqa: C901
 def _copy_nodes(
     src: BaseGraphState,
     dst: BaseGraphState,
-    exclude_nodes: set[int],
+    exclude_nodes: AbstractSet[int],
 ) -> dict[int, int]:
     r"""Copy nodes from src to dst, excluding specified nodes.
 
@@ -744,7 +742,7 @@ def _copy_nodes(
         source graph state
     dst : `BaseGraphState`
         destination graph state
-    exclude_nodes : `set`\[`int`\]
+    exclude_nodes : `collections.abc.Set`\[`int`\]
         set of nodes to exclude from copying
 
     Returns

--- a/graphix_zx/graphstate.py
+++ b/graphix_zx/graphstate.py
@@ -738,9 +738,11 @@ def compose_sequentially(  # noqa: C901
             g.add_physical_edge(a, b)
 
     for u, v in graph1.physical_edges:
-        _add_edge_safe(composed_graph, node_map1[u], node_map1[v])
+        if node_map1[u] not in composed_graph.neighbors(node_map1[v]):
+            composed_graph.add_physical_edge(node_map1[u], node_map1[v])
     for u, v in graph2.physical_edges:
-        _add_edge_safe(composed_graph, node_map2[u], node_map2[v])
+        if node_map2[u] not in composed_graph.neighbors(node_map2[v]):
+            composed_graph.add_physical_edge(node_map2[u], node_map2[v])
 
     return composed_graph, node_map1, node_map2
 

--- a/graphix_zx/graphstate.py
+++ b/graphix_zx/graphstate.py
@@ -701,7 +701,7 @@ def compose_sequentially(
     node_map1 = _copy_nodes(
         src=graph1,
         dst=composed_graph,
-        exclude_nodes=graph1.output_node_indices,
+        exclude_nodes=graph1.output_node_indices.keys(),
     )
     node_map2 = _copy_nodes(
         src=graph2,

--- a/graphix_zx/graphstate.py
+++ b/graphix_zx/graphstate.py
@@ -718,8 +718,7 @@ def compose_sequentially(  # noqa: C901
 
     # map graph1's outputs onto graph2's inputs
     q_index2output_node_index1 = {
-        q_index: output_node_index1
-        for output_node_index1, q_index in graph1.output_node_indices.items()
+        q_index: output_node_index1 for output_node_index1, q_index in graph1.output_node_indices.items()
     }
     for input_node_index2, q_index in graph2.input_node_indices.items():
         node_map1[q_index2output_node_index1[q_index]] = node_map2[input_node_index2]


### PR DESCRIPTION
Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `pytest`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
- Type checking by `mypy` and `pyright`
- Make sure the checks (github actions) pass.
- Check that the docs compile without errors (run `make html` in `./docs/` - you may need to install dependency for sphinx docs, see `docs/requirements.txt`.)

Then, please fill in below:
By moving the construction of`q_index2output_node_index1` before `composed_graph.register_input()`, the bug is fixed. Additionally, the procedure of adding edges to the composed graph is modified to avoid duplication.

**Context (if applicable):**
When a graph in which all nodes are both inputs and outputs is passed as `graph1` to `compose_sequentially`, the process ends up referencing an empty list during execution, causing an error.

**Description of the change:**


**Related issue:**
#81
