### PR TITLE
Generalization of measurement basis in group construction and output measurements

### DIFF
--- a/graphix_zx/pauli_frame.py
+++ b/graphix_zx/pauli_frame.py
@@ -159,16 +159,14 @@ class PauliFrame:
 
         group: set[int] = set()
         for node, axis in target_nodes_with_axes.items():
-            if axis == axis.X:
+            if axis is None or axis == Axis.X:
                 out_basis = "X"
-            elif axis == axis.Z:
+            elif axis == Axis.Z:
                 out_basis = "Z"
-            elif axis == axis.Y:
+            elif axis == Axis.Y:
                 out_basis = "Y"
-            else:
-                out_basis = "X"
 
-            group ^= self._collect_dependent_chain_general(
+            group ^= self._collect_dependent_chain(
                 inv_x_flow=inv_x_flow,
                 inv_z_flow=inv_z_flow,
                 node=node,
@@ -200,7 +198,7 @@ class PauliFrame:
 
         return inv_x_flow, inv_z_flow
 
-    def _collect_dependent_chain_general(
+    def _collect_dependent_chain(
         self,
         inv_x_flow: dict[int, set[int]],
         inv_z_flow: dict[int, set[int]],
@@ -242,8 +240,7 @@ class PauliFrame:
                     parents = inv_x_flow.get(current, set())
                 elif output_basis == "Y":
                     parents = inv_x_flow.get(current, set()) | inv_z_flow.get(current, set())
-                else:
-                    parents = inv_z_flow.get(current, set())
+
             else:
                 plane = self.graphstate.meas_bases[current].plane
                 if plane == Plane.XY:
@@ -252,8 +249,6 @@ class PauliFrame:
                     parents = inv_x_flow.get(current, set())
                 elif plane == Plane.YZ:
                     parents = inv_x_flow.get(current, set()) | inv_z_flow.get(current, set())
-                else:
-                    parents = set()
 
             for p in parents:
                 if p not in tracked:

--- a/graphix_zx/pauli_frame.py
+++ b/graphix_zx/pauli_frame.py
@@ -147,7 +147,7 @@ class PauliFrame:
 
         Parameters
         ----------
-        target_nodes : `Mapping`\[`int`, `Axis`\]
+        target_nodes : `collections.abc.Mapping`\[`int`, `Axis`\]
             The target nodes to get the logical observables group for, with their corresponding measurement axes.
 
         Returns
@@ -174,7 +174,7 @@ class PauliFrame:
 
         Returns
         -------
-        `tuple`\[`Mapping`\[`int`, `set`\[`int`\]\], `Mapping`\[`int`, `set`\[`int`\]\]\]
+        `tuple`\[`collections.abc.Mapping`\[`int`, `set`\[`int`\]\], `collections.abc.Mapping`\[`int`, `set`\[`int`\]\]\]
             The inverse x and z flows.
         """
         inv_x_flow: Mapping[int, set[int]] = {n: set() for n in self.graphstate.physical_nodes}
@@ -203,9 +203,9 @@ class PauliFrame:
 
         Parameters
         ----------
-        inv_x_flow : `Mapping`\[`int`, `set`\[`int`\]\]
+        inv_x_flow : `collections.abc.Mapping`\[`int`, `set`\[`int`\]\]
             Inverse X flow mapping.
-        inv_z_flow : `Mapping`\[`int`, `set`\[`int`\]\]
+        inv_z_flow : `collections.abc.Mapping`\[`int`, `set`\[`int`\]\]
             Inverse Z flow mapping.
         node : `int`
             The starting node.

--- a/graphix_zx/pauli_frame.py
+++ b/graphix_zx/pauli_frame.py
@@ -159,7 +159,6 @@ class PauliFrame:
 
         group: set[int] = set()
         for node, axis in target_nodes_with_axes.items():
-
             group ^= self._collect_dependent_chain(
                 inv_x_flow=inv_x_flow,
                 inv_z_flow=inv_z_flow,

--- a/graphix_zx/pauli_frame.py
+++ b/graphix_zx/pauli_frame.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from graphix_zx.common import Axis, Plane
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from collections.abc import Set as AbstractSet
@@ -122,28 +124,25 @@ class PauliFrame:
         `tuple`\[`list`\[`set`\[`int`\]\], `list`\[`set`\[`int`\]\]\]
             The X and Z parity check groups.
         """
-        inv_z_flow: dict[int, set[int]] = {node: set() for node in self.graphstate.physical_nodes}
-        for node, targets in self.zflow.items():
-            for target in targets:
-                inv_z_flow[target].add(node)
-            inv_z_flow[node] -= {node}
+        inv_x_flow, inv_z_flow = self._build_inverse_flows()
 
         x_groups: list[set[int]] = []
         z_groups: list[set[int]] = []
+
         for syndrome_group in self.x_parity_check_group:
             mbqc_group: set[int] = set()
             for node in syndrome_group:
-                mbqc_group ^= _collect_dependent_chain(inv_z_flow, node)
+                mbqc_group ^= self._collect_dependent_chain(inv_x_flow, inv_z_flow, node, output_basis="X")
             x_groups.append(mbqc_group)
         for syndrome_group in self.z_parity_check_group:
             mbqc_group = set()
             for node in syndrome_group:
-                mbqc_group ^= _collect_dependent_chain(inv_z_flow, node)
+                mbqc_group ^= self._collect_dependent_chain(inv_x_flow, inv_z_flow, node, output_basis="Z")
             z_groups.append(mbqc_group)
 
         return x_groups, z_groups
 
-    def logical_observables_group(self, target_nodes: AbstractSet[int]) -> set[int]:
+    def logical_observables_group(self, target_nodes_with_axes: Mapping[int, Axis]) -> set[int]:
         r"""Get the logical observables group for the given target nodes.
 
         Parameters
@@ -156,27 +155,109 @@ class PauliFrame:
         `set`\[`int`\]
             The logical observables group for the given target nodes.
         """
-        # NOTE: This logic assumes that all the measurements are X-based.
+        inv_x_flow, inv_z_flow = self._build_inverse_flows()
+
         group: set[int] = set()
-        inv_z_flow: dict[int, set[int]] = {node: set() for node in self.graphstate.physical_nodes}
-        for node, targets in self.zflow.items():
-            for target in targets:
-                inv_z_flow[target].add(node)
-            inv_z_flow[node] -= {node}
-        for node in target_nodes:
-            group ^= _collect_dependent_chain(inv_z_flow, node)
+        for node, axis in target_nodes_with_axes.items():
+            if axis == axis.X:
+                out_basis = "X"
+            elif axis == axis.Z:
+                out_basis = "Z"
+            elif axis == axis.Y:
+                out_basis = "Y"
+            else:
+                out_basis = "X"
+
+            group ^= self._collect_dependent_chain_general(
+                inv_x_flow=inv_x_flow,
+                inv_z_flow=inv_z_flow,
+                node=node,
+                output_basis=out_basis,
+            )
+
         return group
 
+    def _build_inverse_flows(self) -> tuple[dict[int, set[int]], dict[int, set[int]]]:
+        r"""Build inverse x/z flows (parent sets) for all physical nodes.
 
-def _collect_dependent_chain(inv_flow: dict[int, set[int]], node: int) -> set[int]:
-    chain: set[int] = set()
-    untracked = {node}
-    tracked: set[int] = set()
-    while untracked:
-        current = untracked.pop()
-        chain ^= {current}
-        for parent in inv_flow.get(current, set()):
-            if parent not in tracked:
-                untracked.add(parent)
-        tracked.add(current)
-    return chain
+        Returns
+        -------
+        `tuple`\[`dict`\[`int`, `set`\[`int`\]\], `dict`\[`int`, `set`\[`int`\]\]\]
+            The inverse x and z flows.
+        """
+        inv_x_flow: dict[int, set[int]] = {n: set() for n in self.graphstate.physical_nodes}
+        inv_z_flow: dict[int, set[int]] = {n: set() for n in self.graphstate.physical_nodes}
+
+        for node, targets in self.xflow.items():
+            for t in targets:
+                inv_x_flow[t].add(node)
+            inv_x_flow[node] -= {node}
+
+        for node, targets in self.zflow.items():
+            for t in targets:
+                inv_z_flow[t].add(node)
+            inv_z_flow[node] -= {node}
+
+        return inv_x_flow, inv_z_flow
+
+    def _collect_dependent_chain_general(
+        self,
+        inv_x_flow: dict[int, set[int]],
+        inv_z_flow: dict[int, set[int]],
+        node: int,
+        output_basis: str | None,
+    ) -> set[int]:
+        r"""Generalized dependent-chain collector that respects measurement planes.
+
+        Parameters
+        ----------
+        inv_x_flow : `dict`\[`int`, `set`\[`int`\]\]
+            Inverse X flow mapping.
+        inv_z_flow : `dict`\[`int`, `set`\[`int`\]\]
+            Inverse Z flow mapping.
+        node : `int`
+            The starting node.
+        output_basis : `str` or `None`
+            The basis of the output node ("X", "Y", "Z", or None). If None, defaults to "X".
+
+        Returns
+        -------
+        `set`\[`int`\]
+            The set of dependent nodes in the chain.
+        """
+        chain: set[int] = set()
+        untracked = {node}
+        tracked: set[int] = set()
+
+        outputs = set(self.graphstate.output_node_indices)
+
+        while untracked:
+            current = untracked.pop()
+            chain ^= {current}
+
+            if current in outputs:
+                if output_basis == "X":
+                    parents = inv_z_flow.get(current, set())
+                elif output_basis == "Z":
+                    parents = inv_x_flow.get(current, set())
+                elif output_basis == "Y":
+                    parents = inv_x_flow.get(current, set()) | inv_z_flow.get(current, set())
+                else:
+                    parents = inv_z_flow.get(current, set())
+            else:
+                plane = self.graphstate.meas_bases[current].plane
+                if plane == Plane.XY:
+                    parents = inv_z_flow.get(current, set())
+                elif plane == Plane.XZ:
+                    parents = inv_x_flow.get(current, set())
+                elif plane == Plane.YZ:
+                    parents = inv_x_flow.get(current, set()) | inv_z_flow.get(current, set())
+                else:
+                    parents = set()
+
+            for p in parents:
+                if p not in tracked:
+                    untracked.add(p)
+            tracked.add(current)
+
+        return chain

--- a/graphix_zx/pauli_frame.py
+++ b/graphix_zx/pauli_frame.py
@@ -198,7 +198,7 @@ class PauliFrame:
 
         return inv_x_flow, inv_z_flow
 
-    def _collect_dependent_chain(
+    def _collect_dependent_chain(  # noqa: C901
         self,
         inv_x_flow: dict[int, set[int]],
         inv_z_flow: dict[int, set[int]],

--- a/graphix_zx/stim_compiler.py
+++ b/graphix_zx/stim_compiler.py
@@ -79,7 +79,8 @@ def stim_compile(  # noqa: C901, PLR0912, PLR0915
             meas_order.append(output_node)
         elif axis == Axis.Y:
             if before_measure_flip_probability > 0.0:
-                stim_str += f"Y_ERROR({before_measure_flip_probability}) {output_node}\n"
+                stim_str += f"X_ERROR({before_measure_flip_probability}) {output_node}\n"
+                stim_str += f"Z_ERROR({before_measure_flip_probability}) {output_node}\n"
             stim_str += f"MY {output_node}\n"
             meas_order.append(output_node)
         elif axis == Axis.Z:

--- a/graphix_zx/stim_compiler.py
+++ b/graphix_zx/stim_compiler.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from graphix_zx.pattern import Pattern
 
 
-def stim_compile(  # noqa: C901, PLR0912
+def stim_compile(  # noqa: C901, PLR0912, PLR0915
     pattern: Pattern,
     logical_observables: Mapping[int, Mapping[int, Axis]] | None = None,
     *,
@@ -102,7 +102,6 @@ def stim_compile(  # noqa: C901, PLR0912
 
     # logical observables
     if logical_observables is not None:
-        qindex_to_output = {q: i for i, q in pattern.output_node_indices.items()}
         for log_idx, obs in logical_observables.items():
             logical_observables_group = pframe.logical_observables_group(obs)
             target_str = ""

--- a/graphix_zx/stim_compiler.py
+++ b/graphix_zx/stim_compiler.py
@@ -79,8 +79,7 @@ def stim_compile(  # noqa: C901, PLR0912
             meas_order.append(output_node)
         elif axis == Axis.Y:
             if before_measure_flip_probability > 0.0:
-                stim_str += f"X_ERROR({before_measure_flip_probability}) {output_node}\n"
-                stim_str += f"Z_ERROR({before_measure_flip_probability}) {output_node}\n"
+                stim_str += f"Y_ERROR({before_measure_flip_probability}) {output_node}\n"
             stim_str += f"MY {output_node}\n"
             meas_order.append(output_node)
         elif axis == Axis.Z:

--- a/graphix_zx/stim_compiler.py
+++ b/graphix_zx/stim_compiler.py
@@ -104,8 +104,7 @@ def stim_compile(  # noqa: C901, PLR0912
     if logical_observables is not None:
         qindex_to_output = {q: i for i, q in pattern.output_node_indices.items()}
         for log_idx, obs in logical_observables.items():
-            target_nodes = {qindex_to_output[q_index] for q_index in obs}
-            logical_observables_group = pframe.logical_observables_group(target_nodes)
+            logical_observables_group = pframe.logical_observables_group(obs)
             target_str = ""
             for node in logical_observables_group:
                 target_str += f"rec[{meas_order.index(node) - len(meas_order)}] "


### PR DESCRIPTION
Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `pytest`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
- Type checking by `mypy` and `pyright`
- Make sure the checks (github actions) pass.
- Check that the docs compile without errors (run `make html` in `./docs/` - you may need to install dependency for sphinx docs, see `docs/requirements.txt`.)

Then, please fill in below:

**Context (if applicable):**
Currently, in `stim_compile` and the group construction in `pauli_frame`, it is assumed that all nodes are measured in the X basis. This must be extended to also include Z and Y measurements.

**Description of the change:**

**Related issue:**
