### PR TITLE
Allow Output Node Measurement

### DIFF
--- a/graphix_zx/graphstate.py
+++ b/graphix_zx/graphstate.py
@@ -524,16 +524,16 @@ class GraphState(BaseGraphState):
         r"""Check if the graph state is in canonical form.
 
         The definition of canonical form is:
-        1. Graph state has the same number of input and output nodes.
+        1. Graph state has at least as many input nodes as output nodes.
         2. No Clifford operators applied.
-        3. All non-output nodes have measurement basis.
+        3. All non-output nodes have measurement basis (output nodes can have measurement basis as well).
 
         Returns
         -------
         `bool`
             `True` if the graph state is in canonical form, `False` otherwise.
         """
-        if len(self.input_node_indices) != len(self.output_node_indices):
+        if len(self.input_node_indices) < len(self.output_node_indices):
             return False
         if self.__local_cliffords:
             return False

--- a/graphix_zx/qompiler.py
+++ b/graphix_zx/qompiler.py
@@ -32,7 +32,6 @@ def qompile(
     zflow: Mapping[int, AbstractSet[int]] | None = None,
     *,
     scheduler: Scheduler | None = None,
-    correct_output: bool = True,
 ) -> Pattern:
     r"""Compile graph state into pattern with x/z correction flows.
 
@@ -49,8 +48,6 @@ def qompile(
         scheduler to schedule the graph state preparation and measurements,
         if `None`, the commands are scheduled in a single slice,
         by default `None`
-    correct_output : `bool`, optional
-        whether to correct outputs or not, by default True
 
     Returns
     -------
@@ -64,7 +61,7 @@ def qompile(
 
     pauli_frame = PauliFrame(graph.physical_nodes, xflow, zflow)
 
-    return _qompile(graph, pauli_frame, scheduler=scheduler, correct_output=correct_output)
+    return _qompile(graph, pauli_frame, scheduler=scheduler)
 
 
 def _qompile(
@@ -72,7 +69,6 @@ def _qompile(
     pauli_frame: PauliFrame,
     *,
     scheduler: Scheduler | None = None,
-    correct_output: bool = True,
 ) -> Pattern:
     """Compile graph state into pattern with a given Pauli frame.
 
@@ -88,8 +84,6 @@ def _qompile(
         scheduler to schedule the graph state preparation and measurements,
         if `None`, the commands are scheduled in a single slice,
         by default `None`
-    correct_output : `bool`, optional
-        whether to correct outputs or not, by default True
 
     Returns
     -------
@@ -122,9 +116,9 @@ def _qompile(
                         prepared_edges.add(edge)
             commands.extend(M(node, meas_bases[node]) for node in measure_nodes)
             commands.extend(N(node) for node in prepare_nodes)
-    if correct_output:
-        commands.extend(X(node=node) for node in graph.output_node_indices)
-        commands.extend(Z(node=node) for node in graph.output_node_indices)
+
+    commands.extend(X(node=node) for node in graph.output_node_indices)
+    commands.extend(Z(node=node) for node in graph.output_node_indices)
 
     return Pattern(
         input_node_indices=graph.input_node_indices,

--- a/graphix_zx/qompiler.py
+++ b/graphix_zx/qompiler.py
@@ -117,8 +117,11 @@ def _qompile(
             commands.extend(M(node, meas_bases[node]) for node in measure_nodes)
             commands.extend(N(node) for node in prepare_nodes)
 
-    commands.extend(X(node=node) for node in graph.output_node_indices)
-    commands.extend(Z(node=node) for node in graph.output_node_indices)
+    for node in graph.output_node_indices:
+        if meas_basis := graph.meas_bases.get(node):
+            commands.append(M(node, meas_basis))
+        else:
+            commands.extend((X(node=node), Z(node=node)))
 
     return Pattern(
         input_node_indices=graph.input_node_indices,

--- a/graphix_zx/qompiler.py
+++ b/graphix_zx/qompiler.py
@@ -56,16 +56,8 @@ def qompile(
     -------
     `Pattern`
         compiled pattern
-
-    Raises
-    ------
-    ValueError
-        1. If the graph state is not in canonical form
-        2. If the x flow or z flow is invalid with respect to the graph state
     """
-    if not graph.is_canonical_form():
-        msg = "Graph state must be in canonical form."
-        raise ValueError(msg)
+    graph.check_canonical_form()
     if zflow is None:
         zflow = {node: odd_neighbors(xflow[node], graph) for node in xflow}
     check_flow(graph, xflow, zflow)

--- a/tests/test_graphstate.py
+++ b/tests/test_graphstate.py
@@ -197,45 +197,48 @@ def test_assign_meas_basis(graph: GraphState) -> None:
     assert graph.meas_bases[node_index].angle == 0.5 * np.pi
 
 
-def test_is_canonical_form_true(canonical_graph: GraphState) -> None:
+def test_check_canonical_form_true(canonical_graph: GraphState) -> None:
     """Test if the graph is in canonical form."""
-    assert canonical_graph.is_canonical_form()
+    canonical_graph.check_canonical_form()
 
 
-def test_is_canonical_form_input_output_mismatch(canonical_graph: GraphState) -> None:
+def test_check_canonical_form_input_output_mismatch(canonical_graph: GraphState) -> None:
     """Test if the graph is in canonical form with input-output mismatch."""
     node_index = canonical_graph.add_physical_node()
     canonical_graph.register_input(node_index)
-    assert not canonical_graph.is_canonical_form()
+    with pytest.raises(ValueError, match="The number of input nodes must be equal to the number of output nodes"):
+        canonical_graph.check_canonical_form()
 
 
-def test_is_canonical_form_with_local_clifford_false(canonical_graph: GraphState) -> None:
+def test_check_canonical_form_with_local_clifford_false(canonical_graph: GraphState) -> None:
     """Test if the graph is in canonical form with local Clifford operator."""
     local_clifford = LocalClifford()
     in_node = next(iter(canonical_graph.input_node_indices))
     canonical_graph.apply_local_clifford(in_node, local_clifford)
-    assert not canonical_graph.is_canonical_form()
+    with pytest.raises(ValueError, match="Clifford operators are applied"):
+        canonical_graph.check_canonical_form()
 
 
-def test_is_canonical_form_with_local_clifford_expansion_true(canonical_graph: GraphState) -> None:
+def test_check_canonical_form_with_local_clifford_expansion_true(canonical_graph: GraphState) -> None:
     """Test if the graph is in canonical form with local Clifford operator expansion."""
     local_clifford = LocalClifford()
     in_node = next(iter(canonical_graph.input_node_indices))
     canonical_graph.apply_local_clifford(in_node, local_clifford)
     canonical_graph.expand_local_cliffords()
-    assert canonical_graph.is_canonical_form()
+    canonical_graph.check_canonical_form()  # Should not raise an exception
 
 
-def test_is_canonical_form_missing_meas_basis_false(canonical_graph: GraphState) -> None:
+def test_check_canonical_form_missing_meas_basis_false(canonical_graph: GraphState) -> None:
     """Test if the graph is in canonical form with missing measurement basis."""
     _ = canonical_graph.add_physical_node()
-    assert not canonical_graph.is_canonical_form()
+    with pytest.raises(ValueError, match="All non-output nodes must have measurement basis"):
+        canonical_graph.check_canonical_form()
 
 
-def test_is_canonical_form_empty_graph_is_true() -> None:
+def test_check_canonical_form_empty_graph_is_true() -> None:
     """Test if an empty graph is in canonical form."""
     graph = GraphState()
-    assert graph.is_canonical_form()
+    graph.check_canonical_form()  # Should not raise an exception
 
 
 def test_check_meas_raises_value_error(graph: GraphState) -> None:


### PR DESCRIPTION
Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `pytest`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
- Type checking by `mypy` and `pyright`
- Make sure the checks (github actions) pass.
- Check that the docs compile without errors (run `make html` in `./docs/` - you may need to install dependency for sphinx docs, see `docs/requirements.txt`.)

Then, please fill in below:

**Context (if applicable):**

For some practical applications, such as sampling experiment and FTQC simulation, output measurements are required.

**Description of the change:**

First, I loosened the definition of `is_canonical_form` to allow output nodes to be measured.
Second, I modified the procedure of `qompile` to add the `M` command on the output nodes.
I also updated the behavior of `is_canonical_form` to explicitly show the error cause.

**Related issue:**

Closes #68, #88 