### PR TITLE
Quick Fix of Workflow name

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -39,7 +39,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Extract version from tag
         id: get_version


### PR DESCRIPTION
Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `pytest`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
- Type checking by `mypy` and `pyright`
- Make sure the checks (github actions) pass.
- Check that the docs compile without errors (run `make html` in `./docs/` - you may need to install dependency for sphinx docs, see `docs/requirements.txt`.)

Then, please fill in below:

**Description of the change:**

The workflow name `pypa/gh-action-pypi-publish@v1` was wrong. I updated it to `pypa/gh-action-pypi-publish@release/v1`.

**Related issue:**
