### PR TITLE
Fix `Scheduler.manual_schedule` to accept reversed `entangle_time` edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Command**: Extended Command type alias to include TICK
 - The default strategy of `Scheduler.solve_schedule` is now `MINIMIZE_TIME` instead of `MINIMIZE_SPACE` for the compilation performance.
 
+### Fixed
+
+- **Scheduler**: Accept `entangle_time` edges in either order in `Scheduler.manual_schedule()`.
+
+### Tests
+
+- **Stim Compiler**: Add coverage that manual `entangle_time` determines CZ time slices in both Pattern and Stim output.
+
 ## [0.1.2] - 2025-10-31
 
 ### Added


### PR DESCRIPTION
Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `pytest`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
- Type checking by `mypy` and `pyright`
- Make sure the checks (github actions) pass.
- Check that the docs compile without errors (run `make html` in `./docs/` - you may need to install dependency for sphinx docs, see `docs/requirements.txt`.)

Then, please fill in below:

**Context (if applicable):**

**Description of the change:**

- Fixes an edge-ordering pitfall where manually provided entangle_time keys in reversed order (e.g., (v, u) instead of (u, v)) were ignored, potentially changing the intended entanglement timing/order.
- Scheduler.manual_schedule() now treats the graph as undirected for entangle_time lookup and resolves both orientations.
- Adds a focused test ensuring manual entangle_time controls CZ placement across time slices in both the generated Pattern and the compiled Stim circuit.

**Related issue:**

NA
