### PR TITLE
Validate provided scheduler before qompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Non-Unitary Parity Projection Example**: Added `examples/nonunitary_parity_projection.py` demonstrating measurement-induced entanglement via a 3-node star graph parity projector
 
+### Fixed
+
+- **Qompiler**: `qompile()` now validates a provided scheduler before pattern generation, so invalid manual schedules fail early with `ValueError`.
+
 ## [0.3.0] - 2026-04-08
 
 ### Added

--- a/graphqomb/qompiler.py
+++ b/graphqomb/qompiler.py
@@ -54,6 +54,7 @@ def qompile(  # noqa: PLR0913
         scheduler to schedule the graph state preparation and measurements,
         if `None`, a `Scheduler` is constructed internally and solved with the
         default ``MINIMIZE_TIME`` strategy before compiling the pattern,
+        otherwise the provided scheduler is validated before compiling the pattern,
         by default `None`
 
     Returns
@@ -97,6 +98,7 @@ def _qompile(
         scheduler to schedule the graph state preparation and measurements,
         if `None`, a `Scheduler` is constructed internally and solved with the
         default ``MINIMIZE_TIME`` strategy before compiling the pattern,
+        otherwise the provided scheduler is validated before compiling the pattern,
         by default `None`
 
     Returns
@@ -112,9 +114,11 @@ def _qompile(
     topo_order.reverse()  # children first
 
     commands: list[Command] = []
-    if not scheduler:
+    if scheduler is None:
         scheduler = Scheduler(graph, pauli_frame.xflow, pauli_frame.zflow)
         scheduler.solve_schedule()
+    else:
+        scheduler.validate_schedule()
 
     timeline = scheduler.timeline
 

--- a/tests/test_scheduler_integration.py
+++ b/tests/test_scheduler_integration.py
@@ -395,6 +395,32 @@ def test_validate_schedule_dag_violations() -> None:
         scheduler2.validate_schedule()
 
 
+def test_qompile_validates_provided_scheduler() -> None:
+    """Qompile should reject invalid schedules before pattern generation."""
+    graph = GraphState()
+    node0 = graph.add_physical_node()
+    node1 = graph.add_physical_node()
+    node2 = graph.add_physical_node()
+    graph.add_physical_edge(node0, node1)
+    graph.add_physical_edge(node1, node2)
+
+    qindex = 0
+    graph.register_input(node0, qindex)
+    graph.register_output(node2, qindex)
+    graph.assign_meas_basis(node0, PlannerMeasBasis(Plane.XY, 0.0))
+    graph.assign_meas_basis(node1, PlannerMeasBasis(Plane.XY, 0.0))
+
+    flow = {node0: {node1}, node1: {node2}}
+    scheduler = Scheduler(graph, flow)
+    scheduler.manual_schedule(
+        prepare_time={node1: 0, node2: 0},
+        measure_time={node0: 2, node1: 1},
+    )
+
+    with pytest.raises(ValueError, match="DAG violation"):
+        qompile(graph, flow, scheduler=scheduler)
+
+
 def test_validate_schedule_same_time_prep_meas() -> None:
     """Test that validate_schedule rejects schedules with nodes prepared and measured at same time."""
     # Create a graph


### PR DESCRIPTION
Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `pytest`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
- Type checking by `mypy` and `pyright`
- Make sure the checks (github actions) pass.
- Check that the docs compile without errors (run `make html` in `./docs/` - you may need to install dependency for sphinx docs, see `docs/requirements.txt`.)

Then, please fill in below:

**Context (if applicable):**

`qompile()` accepted user-provided `Scheduler` instances without validating their schedules first, so invalid manual schedules could reach pattern generation and fail later or produce incorrect command timing.

**Description of the change:**

- Validate a provided scheduler in `_qompile()` before reading its timeline.
- Keep the existing internal scheduler path unchanged when no scheduler is provided.
- Add a regression test covering DAG-violating scheduler input to `qompile()`.
- Record the fix in the Unreleased changelog.

Validation performed locally:

- `python -m ruff check ./graphqomb ./tests ./examples`
- `python -m ruff format --check --diff`
- `python -m pytest -m "not pyzx"`
- `python -m pytest -m pyzx`
- `python -m pytest --cov=graphqomb --cov-report=term-missing --cov-report=xml --cov-branch`
- `python -m mypy`
- `pyright`
- `env PRE_COMMIT_HOME=/tmp/pre-commit pre-commit run --all-files`
- `sphinx-build -W docs/source docs/build`

**Related issue:**

Closes #154