### PR TITLE
Standardize GraphState graph API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Graph State API**: Replaced legacy `physical_*` graph methods/properties with standard graph-style `nodes`, `edges`, `add_node()`, `add_edge()`, `remove_node()`, `remove_edge()`, and count/query helpers.
+
 ## [0.3.1] - 2026-05-17
 
 ### Added

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -53,8 +53,8 @@ Use :func:`graphqomb.circuit.circuit2graph` to derive the graph-state IR, feedfo
 
    graphstate, xflow, scheduler = circuit2graph(circuit)
 
-   print("graph nodes:", len(graphstate.physical_nodes))
-   print("graph edges:", len(graphstate.physical_edges))
+   print("graph nodes:", len(graphstate.nodes))
+   print("graph edges:", len(graphstate.edges))
    print("feedforward entries:", len(xflow))
    print("scheduled slices:", scheduler.num_slices())
 

--- a/examples/draw_graph.py
+++ b/examples/draw_graph.py
@@ -56,7 +56,7 @@ demo_graph, node_map = GraphState.from_graph(
 print("Demo graph with XZ and YZ measurement planes:")
 print(f"Input nodes: {list(demo_graph.input_node_indices.keys())}")
 print(f"Output nodes: {list(demo_graph.output_node_indices.keys())}")
-print(f"All physical nodes: {demo_graph.physical_nodes}")
+print(f"All nodes: {demo_graph.nodes}")
 print("Internal nodes with measurement bases:")
 for node, basis in demo_graph.meas_bases.items():
     print(f"  Node {node}: {basis.plane.name} plane, angle={basis.angle:.3f}")

--- a/examples/entanglement_scheduling_demo.py
+++ b/examples/entanglement_scheduling_demo.py
@@ -39,10 +39,10 @@ node1 = node_map["middle1"]
 node2 = node_map["middle2"]
 node3 = node_map["output"]
 
-print(f"   Nodes: {list(graph.physical_nodes)}")
+print(f"   Nodes: {list(graph.nodes)}")
 print(f"   Input: {list(graph.input_node_indices.keys())}")
 print(f"   Output: {list(graph.output_node_indices.keys())}")
-print(f"   Edges: {list(graph.physical_edges)}")
+print(f"   Edges: {list(graph.edges)}")
 
 # Define flow
 flow = {node0: {node1}, node1: {node2}, node2: {node3}}

--- a/examples/pattern_from_circuit.py
+++ b/examples/pattern_from_circuit.py
@@ -31,8 +31,8 @@ circuit.cz(1, 2)
 # %%
 # Convert the circuit into GraphQOMB's compiler IRs.
 graphstate, xflow, scheduler = circuit2graph(circuit)
-print("graph nodes:", len(graphstate.physical_nodes))
-print("graph edges:", len(graphstate.physical_edges))
+print("graph nodes:", len(graphstate.nodes))
+print("graph edges:", len(graphstate.edges))
 print("feedforward entries:", len(xflow))
 print("scheduled slices:", scheduler.num_slices())
 

--- a/examples/pattern_generation.py
+++ b/examples/pattern_generation.py
@@ -18,8 +18,8 @@ from graphqomb.random_objects import generate_random_flow_graph
 # Generate a labelled graph state and its X-correction map.
 graphstate, xflow = generate_random_flow_graph(width=3, depth=5)
 
-print("graph nodes:", len(graphstate.physical_nodes))
-print("graph edges:", len(graphstate.physical_edges))
+print("graph nodes:", len(graphstate.nodes))
+print("graph edges:", len(graphstate.edges))
 
 # Lower the graph/feedforward IRs to an executable pattern.
 pattern = qompile(graphstate, xflow)

--- a/examples/scheduler_pattern_demo.py
+++ b/examples/scheduler_pattern_demo.py
@@ -17,10 +17,10 @@ from graphqomb.scheduler import Scheduler
 print("=== Scheduler-based Pattern Generation Demo ===\n")
 print("1. Creating sample graph state...")
 graph, xflow = generate_random_flow_graph(width=3, depth=3, edge_p=0.7)
-print(f"   Graph has {len(graph.physical_nodes)} nodes")
+print(f"   Graph has {len(graph.nodes)} nodes")
 print(f"   Input nodes: {list(graph.input_node_indices.keys())}")
 print(f"   Output nodes: {list(graph.output_node_indices.keys())}")
-print(f"   Edges: {len(graph.physical_edges)}")
+print(f"   Edges: {len(graph.edges)}")
 
 # %%
 # Demonstrate space-optimized scheduling

--- a/graphqomb/circuit.py
+++ b/graphqomb/circuit.py
@@ -86,8 +86,8 @@ class _Circuit2GraphContext:
         raise TypeError(msg)
 
     def _apply_j(self, instruction: J) -> None:
-        new_node = self.graph.add_physical_node()
-        self.graph.add_physical_edge(self.qindex2front_nodes[instruction.qubit], new_node)
+        new_node = self.graph.add_node()
+        self.graph.add_edge(self.qindex2front_nodes[instruction.qubit], new_node)
         self.graph.assign_meas_basis(
             self.qindex2front_nodes[instruction.qubit],
             PlannerMeasBasis(Plane.XY, -instruction.angle),
@@ -106,7 +106,7 @@ class _Circuit2GraphContext:
         self.qindex2front_nodes[instruction.qubit] = new_node
 
     def _apply_cz(self, instruction: CZ) -> None:
-        self.graph.add_physical_edge(
+        self.graph.add_edge(
             self.qindex2front_nodes[instruction.qubits[0]],
             self.qindex2front_nodes[instruction.qubits[1]],
         )
@@ -119,10 +119,10 @@ class _Circuit2GraphContext:
         self.qindex2timestep[instruction.qubits[1]] = aligned_time
 
     def _apply_phase_gadget(self, instruction: PhaseGadget) -> None:
-        new_node = self.graph.add_physical_node()
+        new_node = self.graph.add_node()
         self.graph.assign_meas_basis(new_node, PlannerMeasBasis(Plane.YZ, instruction.angle))
         for qubit in instruction.qubits:
-            self.graph.add_physical_edge(self.qindex2front_nodes[qubit], new_node)
+            self.graph.add_edge(self.qindex2front_nodes[qubit], new_node)
 
         self.gflow[new_node] = {new_node}
 
@@ -349,7 +349,7 @@ def circuit2graph(
 
     # input nodes
     for i in range(circuit.num_qubits):
-        node = graph.add_physical_node()
+        node = graph.add_node()
         graph.register_input(node, i)
         context.qindex2front_nodes[i] = node
         context.qindex2timestep[i] = 0

--- a/graphqomb/feedforward.py
+++ b/graphqomb/feedforward.py
@@ -86,7 +86,7 @@ def dag_from_flow(
     """  # noqa: E501
     dag: dict[int, set[int]] = {}
     output_nodes = set(graph.output_node_indices)
-    non_output_nodes = graph.physical_nodes - output_nodes
+    non_output_nodes = graph.nodes - output_nodes
     if _is_flow(xflow):
         xflow = {node: {xflow[node]} for node in xflow}
     elif _is_gflow(xflow):
@@ -367,7 +367,7 @@ def pauli_simplification(  # noqa: C901, PLR0912
         for v in vs:
             inv_zflow.setdefault(v, set()).add(k)
 
-    for node in graph.physical_nodes - graph.output_node_indices.keys():
+    for node in graph.nodes - graph.output_node_indices.keys():
         meas_basis = graph.meas_bases.get(node)
         if meas_basis is None:
             continue

--- a/graphqomb/focus_flow.py
+++ b/graphqomb/focus_flow.py
@@ -97,7 +97,7 @@ def focus_gflow(
         msg = "Invalid flowlike object"
         raise TypeError(msg)
     check_flow(graph, flowlike)
-    outputs = graph.physical_nodes - set(flowlike)
+    outputs = graph.nodes - set(flowlike)
     dag = dag_from_flow(graph, flowlike)
     topo_order = list(TopologicalSorter(dag).static_order())
     topo_order.reverse()  # children first

--- a/graphqomb/graphstate.py
+++ b/graphqomb/graphstate.py
@@ -62,24 +62,24 @@ class BaseGraphState(ABC):
 
     @property
     @abc.abstractmethod
-    def physical_nodes(self) -> set[int]:
-        r"""Return set of physical nodes.
+    def nodes(self) -> set[int]:
+        r"""Return set of nodes.
 
         Returns
         -------
         `set`\[`int`\]
-            set of physical nodes.
+            set of nodes.
         """
 
     @property
     @abc.abstractmethod
-    def physical_edges(self) -> set[tuple[int, int]]:
-        r"""Return set of physical edges.
+    def edges(self) -> set[tuple[int, int]]:
+        r"""Return set of edges.
 
         Returns
         -------
         `set`\[`tuple`\[`int`, `int`\]`
-            set of physical edges.
+            set of edges.
         """
 
     @property
@@ -90,27 +90,29 @@ class BaseGraphState(ABC):
         Returns
         -------
         `types.MappingProxyType`\[`int`, `MeasBasis`\]
-            measurement bases of each physical node.
+            measurement bases of each node.
         """
 
     @abc.abstractmethod
-    def add_physical_node(self, coordinate: tuple[float, ...] | None = None) -> int:
-        r"""Add a physical node to the graph state.
+    def add_node(self, node: int | None = None, *, coordinate: tuple[float, ...] | None = None) -> int:
+        r"""Add a node to the graph state.
 
         Parameters
         ----------
+        node : `int` | `None`, optional
+            node index to add. If None, an index is generated.
         coordinate : `tuple`\[`float`, ...\] | `None`, optional
             coordinate tuple (2D or 3D), by default None
 
         Returns
         -------
         `int`
-            The node index internally generated
+            The added node index.
         """
 
     @abc.abstractmethod
-    def add_physical_edge(self, node1: int, node2: int) -> None:
-        """Add a physical edge to the graph state.
+    def add_edge(self, node1: int, node2: int) -> None:
+        """Add an edge to the graph state.
 
         Parameters
         ----------
@@ -119,6 +121,57 @@ class BaseGraphState(ABC):
         node2 : `int`
             node index
         """
+
+    def remove_node(self, node: int) -> None:
+        """Remove a node from the graph state."""
+        msg = f"{type(self).__name__} does not support node removal"
+        raise NotImplementedError(msg)
+
+    def remove_edge(self, node1: int, node2: int) -> None:
+        """Remove an edge from the graph state."""
+        msg = f"{type(self).__name__} does not support edge removal"
+        raise NotImplementedError(msg)
+
+    def has_node(self, node: int) -> bool:
+        """Return whether the graph state contains a node.
+
+        Returns
+        -------
+        `bool`
+            Whether the node exists.
+        """
+        return node in self.nodes
+
+    def has_edge(self, node1: int, node2: int) -> bool:
+        """Return whether the graph state contains an edge.
+
+        Returns
+        -------
+        `bool`
+            Whether the edge exists.
+        """
+        edge = (node1, node2) if node1 < node2 else (node2, node1)
+        return edge in self.edges
+
+    def number_of_nodes(self) -> int:
+        """Return the number of nodes.
+
+        Returns
+        -------
+        `int`
+            Number of nodes.
+        """
+        return len(self.nodes)
+
+    def number_of_edges(self) -> int:
+        """Return the number of edges.
+
+        Returns
+        -------
+        `int`
+            Number of edges.
+        """
+        return len(self.edges)
 
     @abc.abstractmethod
     def register_input(self, node: int, q_index: int) -> None:
@@ -192,21 +245,21 @@ class GraphState(BaseGraphState):
 
     __input_node_indices: dict[int, int]
     __output_node_indices: dict[int, int]
-    __physical_nodes: set[int]
-    __physical_edges: dict[int, set[int]]
+    __nodes: set[int]
+    __neighbors: dict[int, set[int]]
     __meas_bases: dict[int, MeasBasis]
     __local_cliffords: dict[int, LocalClifford]
     __coordinates: dict[int, tuple[float, ...]]
 
     __node_counter: int
 
-    _cached_physical_nodes: frozenset[int] | None = None
+    _cached_nodes: frozenset[int] | None = None
 
     def __init__(self) -> None:
         self.__input_node_indices = {}
         self.__output_node_indices = {}
-        self.__physical_nodes = set()
-        self.__physical_edges = {}
+        self.__nodes = set()
+        self.__neighbors = {}
         self.__meas_bases = {}
         self.__local_cliffords = {}
         self.__coordinates = {}
@@ -239,31 +292,31 @@ class GraphState(BaseGraphState):
 
     @property
     @typing_extensions.override
-    def physical_nodes(self) -> set[int]:
-        r"""Return set of physical nodes.
+    def nodes(self) -> set[int]:
+        r"""Return set of nodes.
 
         Returns
         -------
         `set`\[`int`\]
-            set of physical nodes.
+            set of nodes.
         """
-        if self._cached_physical_nodes is None:
-            self._cached_physical_nodes = frozenset(self.__physical_nodes)
-        return set(self._cached_physical_nodes)
+        if self._cached_nodes is None:
+            self._cached_nodes = frozenset(self.__nodes)
+        return set(self._cached_nodes)
 
     @property
     @typing_extensions.override
-    def physical_edges(self) -> set[tuple[int, int]]:
-        r"""Return set of physical edges.
+    def edges(self) -> set[tuple[int, int]]:
+        r"""Return set of edges.
 
         Returns
         -------
         `set`\[`tuple`\[`int`, `int`\]
-            set of physical edges.
+            set of edges.
         """
         edges: set[tuple[int, int]] = set()
-        for node1 in self.__physical_edges:
-            for node2 in self.__physical_edges[node1]:
+        for node1 in self.__neighbors:
+            for node2 in self.__neighbors[node1]:
                 if node1 < node2:
                     edges |= {(node1, node2)}
         return edges
@@ -276,7 +329,7 @@ class GraphState(BaseGraphState):
         Returns
         -------
         `types.MappingProxyType`\[`int`, `MeasBasis`\]
-            measurement bases of each physical node.
+            measurement bases of each node.
         """
         return MappingProxyType(self.__meas_bases)
 
@@ -317,14 +370,14 @@ class GraphState(BaseGraphState):
         self.__coordinates[node] = coord
 
     def _check_meas_basis(self) -> None:
-        """Check if the measurement basis is set for all physical nodes except output nodes.
+        """Check if the measurement basis is set for all nodes except output nodes.
 
         Raises
         ------
         ValueError
             If the measurement basis is not set for a node or the measurement plane is invalid.
         """
-        for v in self.physical_nodes - set(self.output_node_indices):
+        for v in self.nodes - set(self.output_node_indices):
             if self.meas_bases.get(v) is None:
                 msg = f"Measurement basis not set for node {v}"
                 raise ValueError(msg)
@@ -337,37 +390,48 @@ class GraphState(BaseGraphState):
         ValueError
             If the node does not exist in the graph state.
         """
-        if node not in self.__physical_nodes:
+        if node not in self.__nodes:
             msg = f"Node does not exist {node=}"
             raise ValueError(msg)
 
     @typing_extensions.override
-    def add_physical_node(self, coordinate: tuple[float, ...] | None = None) -> int:
-        r"""Add a physical node to the graph state.
+    def add_node(self, node: int | None = None, *, coordinate: tuple[float, ...] | None = None) -> int:
+        r"""Add a node to the graph state.
 
         Parameters
         ----------
+        node : `int` | `None`, optional
+            node index to add. If None, an index is generated.
         coordinate : `tuple`\[`float`, ...\] | `None`, optional
             coordinate tuple (2D or 3D), by default None
 
         Returns
         -------
         `int`
-            The node index internally generated.
+            The added node index.
+
+        Raises
+        ------
+        ValueError
+            If the node already exists.
         """
-        node = self.__node_counter
-        self.__physical_nodes |= {node}
-        self.__physical_edges[node] = set()
+        if node is None:
+            node = self.__node_counter
+        elif node in self.__nodes:
+            msg = f"Node already exists {node=}"
+            raise ValueError(msg)
+        self.__nodes |= {node}
+        self.__neighbors[node] = set()
         if coordinate is not None:
             self.__coordinates[node] = coordinate
-        self.__node_counter += 1
-        self._cached_physical_nodes = None
+        self.__node_counter = max(self.__node_counter, node + 1)
+        self._cached_nodes = None
 
         return node
 
     @typing_extensions.override
-    def add_physical_edge(self, node1: int, node2: int) -> None:
-        """Add a physical edge to the graph state.
+    def add_edge(self, node1: int, node2: int) -> None:
+        """Add an edge to the graph state.
 
         Parameters
         ----------
@@ -385,17 +449,18 @@ class GraphState(BaseGraphState):
         """
         self._ensure_node_exists(node1)
         self._ensure_node_exists(node2)
-        if node1 in self.__physical_edges[node2] or node2 in self.__physical_edges[node1]:
+        if node1 in self.__neighbors[node2] or node2 in self.__neighbors[node1]:
             msg = f"Edge already exists {node1=}, {node2=}"
             raise ValueError(msg)
         if node1 == node2:
             msg = "Self-loops are not allowed"
             raise ValueError(msg)
-        self.__physical_edges[node1] |= {node2}
-        self.__physical_edges[node2] |= {node1}
+        self.__neighbors[node1] |= {node2}
+        self.__neighbors[node2] |= {node1}
 
-    def remove_physical_node(self, node: int) -> None:
-        """Remove a physical node from the graph state.
+    @typing_extensions.override
+    def remove_node(self, node: int) -> None:
+        """Remove a node from the graph state.
 
         Parameters
         ----------
@@ -411,10 +476,10 @@ class GraphState(BaseGraphState):
         if node in self.input_node_indices:
             msg = "The input node cannot be removed"
             raise ValueError(msg)
-        self.__physical_nodes -= {node}
-        for neighbor in self.__physical_edges[node]:
-            self.__physical_edges[neighbor] -= {node}
-        del self.__physical_edges[node]
+        self.__nodes -= {node}
+        for neighbor in self.__neighbors[node]:
+            self.__neighbors[neighbor] -= {node}
+        del self.__neighbors[node]
 
         if node in self.output_node_indices:
             del self.__output_node_indices[node]
@@ -422,10 +487,11 @@ class GraphState(BaseGraphState):
         self.__local_cliffords.pop(node, None)
         self.__coordinates.pop(node, None)
 
-        self._cached_physical_nodes = None
+        self._cached_nodes = None
 
-    def remove_physical_edge(self, node1: int, node2: int) -> None:
-        """Remove a physical edge from the graph state.
+    @typing_extensions.override
+    def remove_edge(self, node1: int, node2: int) -> None:
+        """Remove an edge from the graph state.
 
         Parameters
         ----------
@@ -441,11 +507,11 @@ class GraphState(BaseGraphState):
         """
         self._ensure_node_exists(node1)
         self._ensure_node_exists(node2)
-        if node1 not in self.__physical_edges[node2] or node2 not in self.__physical_edges[node1]:
+        if node1 not in self.__neighbors[node2] or node2 not in self.__neighbors[node1]:
             msg = "Edge does not exist"
             raise ValueError(msg)
-        self.__physical_edges[node1] -= {node2}
-        self.__physical_edges[node2] -= {node1}
+        self.__neighbors[node1] -= {node2}
+        self.__neighbors[node2] -= {node1}
 
     @typing_extensions.override
     def register_input(self, node: int, q_index: int) -> None:
@@ -551,7 +617,7 @@ class GraphState(BaseGraphState):
             set of neighboring nodes
         """
         self._ensure_node_exists(node)
-        return self.__physical_edges[node].copy()
+        return self.__neighbors[node].copy()
 
     @typing_extensions.override
     def check_canonical_form(self) -> None:
@@ -569,7 +635,7 @@ class GraphState(BaseGraphState):
         if self.__local_cliffords:
             msg = "Clifford operators are applied."
             raise ValueError(msg)
-        for node in self.physical_nodes - self.output_node_indices.keys():
+        for node in self.nodes - self.output_node_indices.keys():
             if self.meas_bases.get(node) is None:
                 msg = "All non-output nodes must have measurement basis."
                 raise ValueError(msg)
@@ -617,14 +683,14 @@ class GraphState(BaseGraphState):
                 new_input_indices[input_node] = q_index
                 continue
 
-            new_node_index0 = self.add_physical_node()
+            new_node_index0 = self.add_node()
             new_input_indices[new_node_index0] = q_index
-            new_node_index1 = self.add_physical_node()
-            new_node_index2 = self.add_physical_node()
+            new_node_index1 = self.add_node()
+            new_node_index2 = self.add_node()
 
-            self.add_physical_edge(new_node_index0, new_node_index1)
-            self.add_physical_edge(new_node_index1, new_node_index2)
-            self.add_physical_edge(new_node_index2, input_node)
+            self.add_edge(new_node_index0, new_node_index1)
+            self.add_edge(new_node_index1, new_node_index2)
+            self.add_edge(new_node_index2, input_node)
 
             self.assign_meas_basis(new_node_index0, PlannerMeasBasis(Plane.XY, lc.alpha))
             self.assign_meas_basis(new_node_index1, PlannerMeasBasis(Plane.XY, lc.beta))
@@ -656,14 +722,14 @@ class GraphState(BaseGraphState):
                 new_output_index_map[output_node] = q_index
                 continue
 
-            new_node_index0 = self.add_physical_node()
-            new_node_index1 = self.add_physical_node()
-            new_node_index2 = self.add_physical_node()
+            new_node_index0 = self.add_node()
+            new_node_index1 = self.add_node()
+            new_node_index2 = self.add_node()
             new_output_index_map[new_node_index2] = q_index
 
-            self.add_physical_edge(output_node, new_node_index0)
-            self.add_physical_edge(new_node_index0, new_node_index1)
-            self.add_physical_edge(new_node_index1, new_node_index2)
+            self.add_edge(output_node, new_node_index0)
+            self.add_edge(new_node_index0, new_node_index1)
+            self.add_edge(new_node_index1, new_node_index2)
 
             self.assign_meas_basis(output_node, PlannerMeasBasis(Plane.XY, lc.alpha))
             self.assign_meas_basis(new_node_index0, PlannerMeasBasis(Plane.XY, lc.beta))
@@ -766,14 +832,14 @@ class GraphState(BaseGraphState):
         # Add nodes and create node mapping
         node_map: dict[NodeT, int] = {}
         for node in nodes_list:
-            new_node = graph_state.add_physical_node()
+            new_node = graph_state.add_node()
             node_map[node] = new_node
 
         # Add edges
         for node1, node2 in edges_list:
             idx1 = node_map[node1]
             idx2 = node_map[node2]
-            graph_state.add_physical_edge(idx1, idx2)
+            graph_state.add_edge(idx1, idx2)
 
         # Register inputs with sequential qubit indices
         if inputs is not None:
@@ -832,13 +898,13 @@ class GraphState(BaseGraphState):
 
         # Create node mapping
         node_map: dict[int, int] = {}
-        for node in base.physical_nodes:
-            new_node = graph_state.add_physical_node()
+        for node in base.nodes:
+            new_node = graph_state.add_node()
             node_map[node] = new_node
 
         # Add edges using node mapping
-        for node1, node2 in base.physical_edges:
-            graph_state.add_physical_edge(node_map[node1], node_map[node2])
+        for node1, node2 in base.edges:
+            graph_state.add_edge(node_map[node1], node_map[node2])
 
         # Register inputs with same qubit indices
         for input_node, q_index in base.input_node_indices.items():
@@ -966,10 +1032,10 @@ def compose(  # noqa: C901, PLR0912
     for output_node, q_index in graph2.output_node_indices.items():
         composed_graph.register_output(node_map2[output_node], q_index)
 
-    for u, v in graph1.physical_edges:
-        composed_graph.add_physical_edge(node_map1[u], node_map1[v])
-    for u, v in graph2.physical_edges:
-        composed_graph.add_physical_edge(node_map2[u], node_map2[v])
+    for u, v in graph1.edges:
+        composed_graph.add_edge(node_map1[u], node_map1[v])
+    for u, v in graph2.edges:
+        composed_graph.add_edge(node_map2[u], node_map2[v])
 
     # Copy coordinates from graph1
     for node, coord in graph1.coordinates.items():
@@ -1006,10 +1072,10 @@ def _copy_nodes(
         mapping from src node indices to dst node indices
     """
     node_map: dict[int, int] = {}
-    for node in src.physical_nodes:
+    for node in src.nodes:
         if node in exclude_nodes:
             continue
-        new_idx = dst.add_physical_node()
+        new_idx = dst.add_node()
         meas = src.meas_bases.get(node)
         if meas is not None:
             dst.assign_meas_basis(new_idx, meas)

--- a/graphqomb/greedy_scheduler.py
+++ b/graphqomb/greedy_scheduler.py
@@ -64,14 +64,14 @@ def greedy_minimize_time(  # noqa: PLR0914
         If the scheduling cannot proceed due to cyclic dependencies
         or if the max_qubit_count constraint is too tight to allow any progress.
     """
-    unmeasured = graph.physical_nodes - graph.output_node_indices.keys()
+    unmeasured = graph.nodes - graph.output_node_indices.keys()
     input_nodes = set(graph.input_node_indices.keys())
     output_nodes = set(graph.output_node_indices.keys())
 
-    inv_dag = inverse_dag_from_dag(dag, graph.physical_nodes)
+    inv_dag = inverse_dag_from_dag(dag, graph.nodes)
 
     # Cache neighbors to avoid repeated set constructions in tight loops
-    neighbors_map = {node: graph.neighbors(node) for node in graph.physical_nodes}
+    neighbors_map = {node: graph.neighbors(node) for node in graph.nodes}
 
     # Single implementation for both bounded and unbounded capacity modes.
     prepare_time: dict[int, int] = {}
@@ -84,7 +84,7 @@ def greedy_minimize_time(  # noqa: PLR0914
     prepared: set[int] = set(input_nodes)
     alive: set[int] = set(input_nodes)
 
-    effective_max_qubit_count = max_qubit_count if max_qubit_count is not None else len(graph.physical_nodes)
+    effective_max_qubit_count = max_qubit_count if max_qubit_count is not None else len(graph.nodes)
 
     if len(alive) > effective_max_qubit_count:
         msg = "Initial number of active qubits exceeds max_qubit_count."
@@ -109,7 +109,7 @@ def greedy_minimize_time(  # noqa: PLR0914
         )
         prepared_in_phase2 = _phase2_prepare_nodes_with_slack(
             current_time,
-            physical_nodes=graph.physical_nodes,
+            nodes=graph.nodes,
             max_qubit_count=effective_max_qubit_count,
             inv_dag=inv_dag_mut,
             neighbors_map=neighbors_map,
@@ -143,13 +143,13 @@ def greedy_minimize_time(  # noqa: PLR0914
         current_time += 1
 
         # Safety check for infinite loops
-        if current_time > len(graph.physical_nodes) * 2:
+        if current_time > len(graph.nodes) * 2:
             msg = "Scheduling did not converge; possible cyclic dependency."
             raise RuntimeError(msg)
 
     _prepare_remaining_nodes_at_tail(
         current_time,
-        physical_nodes=graph.physical_nodes,
+        nodes=graph.nodes,
         input_nodes=input_nodes,
         max_qubit_count=effective_max_qubit_count,
         prepared=prepared,
@@ -166,7 +166,7 @@ def greedy_minimize_time(  # noqa: PLR0914
 def _prepare_remaining_nodes_at_tail(  # noqa: PLR0913
     current_time: int,
     *,
-    physical_nodes: AbstractSet[int],
+    nodes: AbstractSet[int],
     input_nodes: AbstractSet[int],
     max_qubit_count: int,
     prepared: set[int],
@@ -175,7 +175,7 @@ def _prepare_remaining_nodes_at_tail(  # noqa: PLR0913
 ) -> None:
     # Any remaining nodes are outputs that were never needed for a measurement.
     # With no future measurements to free qubits, they must all fit in the final live set.
-    remaining = physical_nodes - input_nodes - prepared
+    remaining = nodes - input_nodes - prepared
     if not remaining:
         return
 
@@ -254,7 +254,7 @@ def _has_initial_input_input_entanglement_wait(
 def _phase2_prepare_nodes_with_slack(  # noqa: PLR0913
     current_time: int,
     *,
-    physical_nodes: AbstractSet[int],
+    nodes: AbstractSet[int],
     max_qubit_count: int,
     inv_dag: Mapping[int, AbstractSet[int]],
     neighbors_map: Mapping[int, AbstractSet[int]],
@@ -269,7 +269,7 @@ def _phase2_prepare_nodes_with_slack(  # noqa: PLR0913
     if free_capacity <= 0:
         return False
 
-    unprepared = physical_nodes - prepared
+    unprepared = nodes - prepared
     if not unprepared:
         return False
 
@@ -397,9 +397,9 @@ def greedy_minimize_space(  # noqa: PLR0914
     prepare_time: dict[int, int] = {}
     measure_time: dict[int, int] = {}
 
-    unmeasured = graph.physical_nodes - graph.output_node_indices.keys()
+    unmeasured = graph.nodes - graph.output_node_indices.keys()
 
-    inv_dag = inverse_dag_from_dag(dag, graph.physical_nodes)
+    inv_dag = inverse_dag_from_dag(dag, graph.nodes)
     topo_order = topo_order_from_inv_dag(inv_dag)  # from parents to children
     topo_rank = {node: i for i, node in enumerate(topo_order)}
 
@@ -409,7 +409,7 @@ def greedy_minimize_space(  # noqa: PLR0914
     current_time = 0
 
     # Cache neighbors once as the graph is static during scheduling
-    neighbors_map = {node: graph.neighbors(node) for node in graph.physical_nodes}
+    neighbors_map = {node: graph.neighbors(node) for node in graph.nodes}
 
     measure_candidates: set[int] = {node for node in unmeasured if not inv_dag[node]}
 
@@ -462,7 +462,7 @@ def greedy_minimize_space(  # noqa: PLR0914
         current_time = meas_time + 1
 
     # Any nodes left here were never needed to unlock a measurement.
-    remaining = graph.physical_nodes - input_nodes - prepared
+    remaining = graph.nodes - input_nodes - prepared
     for node in sorted(remaining):
         prepare_time[node] = current_time
 

--- a/graphqomb/pauli_frame.py
+++ b/graphqomb/pauli_frame.py
@@ -69,8 +69,8 @@ class PauliFrame:
         self.graphstate = graphstate
         self.xflow = {node: set(targets) for node, targets in xflow.items()}
         self.zflow = {node: set(targets) for node, targets in zflow.items()}
-        self.x_pauli = dict.fromkeys(graphstate.physical_nodes, False)
-        self.z_pauli = dict.fromkeys(graphstate.physical_nodes, False)
+        self.x_pauli = dict.fromkeys(graphstate.nodes, False)
+        self.z_pauli = dict.fromkeys(graphstate.nodes, False)
         self.parity_check_group = [set(item) for item in parity_check_group]
         self.logical_observables = {
             logical_idx: set(seed_nodes) for logical_idx, seed_nodes in logical_observables.items()

--- a/graphqomb/ptn_format.py
+++ b/graphqomb/ptn_format.py
@@ -529,8 +529,8 @@ class _LoadedGraphState(BaseGraphState):
 
     _input_node_indices: dict[int, int]
     _output_node_indices: dict[int, int]
-    _physical_nodes: set[int]
-    _physical_edges: set[tuple[int, int]]
+    _nodes: set[int]
+    _edges: set[tuple[int, int]]
     _meas_bases: dict[int, MeasBasis]
     _coordinates: dict[int, tuple[float, ...]]
     _neighbors: dict[int, set[int]] = field(init=False, repr=False)
@@ -538,14 +538,14 @@ class _LoadedGraphState(BaseGraphState):
     def __post_init__(self) -> None:
         self._input_node_indices = dict(self._input_node_indices)
         self._output_node_indices = dict(self._output_node_indices)
-        self._physical_nodes = set(self._physical_nodes)
-        self._physical_edges = {
-            (node1, node2) if node1 < node2 else (node2, node1) for node1, node2 in self._physical_edges
+        self._nodes = set(self._nodes)
+        self._edges = {
+            (node1, node2) if node1 < node2 else (node2, node1) for node1, node2 in self._edges
         }
         self._meas_bases = dict(self._meas_bases)
         self._coordinates = dict(self._coordinates)
-        self._neighbors: dict[int, set[int]] = {node: set() for node in self._physical_nodes}
-        for node1, node2 in self._physical_edges:
+        self._neighbors: dict[int, set[int]] = {node: set() for node in self._nodes}
+        for node1, node2 in self._edges:
             self._neighbors.setdefault(node1, set()).add(node2)
             self._neighbors.setdefault(node2, set()).add(node1)
 
@@ -558,12 +558,12 @@ class _LoadedGraphState(BaseGraphState):
         return self._output_node_indices.copy()
 
     @property
-    def physical_nodes(self) -> set[int]:
-        return set(self._physical_nodes)
+    def nodes(self) -> set[int]:
+        return set(self._nodes)
 
     @property
-    def physical_edges(self) -> set[tuple[int, int]]:
-        return set(self._physical_edges)
+    def edges(self) -> set[tuple[int, int]]:
+        return set(self._edges)
 
     @property
     def meas_bases(self) -> MappingProxyType[int, MeasBasis]:
@@ -573,11 +573,11 @@ class _LoadedGraphState(BaseGraphState):
     def coordinates(self) -> dict[int, tuple[float, ...]]:
         return self._coordinates.copy()
 
-    def add_physical_node(self, coordinate: tuple[float, ...] | None = None) -> int:
+    def add_node(self, node: int | None = None, *, coordinate: tuple[float, ...] | None = None) -> int:
         msg = "Loaded .ptn graph states are read-only"
         raise NotImplementedError(msg)
 
-    def add_physical_edge(self, node1: int, node2: int) -> None:
+    def add_edge(self, node1: int, node2: int) -> None:
         msg = "Loaded .ptn graph states are read-only"
         raise NotImplementedError(msg)
 
@@ -594,13 +594,13 @@ class _LoadedGraphState(BaseGraphState):
         raise NotImplementedError(msg)
 
     def neighbors(self, node: int) -> set[int]:
-        if node not in self._physical_nodes:
+        if node not in self._nodes:
             msg = f"Node does not exist node={node}"
             raise ValueError(msg)
         return self._neighbors.get(node, set()).copy()
 
     def check_canonical_form(self) -> None:
-        for node in self._physical_nodes - self._output_node_indices.keys():
+        for node in self._nodes - self._output_node_indices.keys():
             if node not in self._meas_bases:
                 msg = f"Measurement basis not set for node {node}"
                 raise ValueError(msg)
@@ -667,8 +667,8 @@ def _build_pattern(data: _PatternData) -> Pattern:
     graphstate = _LoadedGraphState(
         _input_node_indices=data.input_node_indices,
         _output_node_indices=data.output_node_indices,
-        _physical_nodes=nodes,
-        _physical_edges=edges,
+        _nodes=nodes,
+        _edges=edges,
         _meas_bases=meas_bases,
         _coordinates=coordinates,
     )

--- a/graphqomb/ptn_format.py
+++ b/graphqomb/ptn_format.py
@@ -539,9 +539,7 @@ class _LoadedGraphState(BaseGraphState):
         self._input_node_indices = dict(self._input_node_indices)
         self._output_node_indices = dict(self._output_node_indices)
         self._nodes = set(self._nodes)
-        self._edges = {
-            (node1, node2) if node1 < node2 else (node2, node1) for node1, node2 in self._edges
-        }
+        self._edges = {(node1, node2) if node1 < node2 else (node2, node1) for node1, node2 in self._edges}
         self._meas_bases = dict(self._meas_bases)
         self._coordinates = dict(self._coordinates)
         self._neighbors: dict[int, set[int]] = {node: set() for node in self._nodes}

--- a/graphqomb/random_objects.py
+++ b/graphqomb/random_objects.py
@@ -54,7 +54,7 @@ def generate_random_flow_graph(
 
     # input nodes
     for i in range(width):
-        node_index = graph.add_physical_node()
+        node_index = graph.add_node()
         graph.register_input(node_index, i)
         graph.assign_meas_basis(node_index, default_meas_basis())
 
@@ -62,21 +62,21 @@ def generate_random_flow_graph(
     for _ in range(depth - 2):
         node_indices_layer: list[int] = []
         for _ in range(width):
-            node_index = graph.add_physical_node()
+            node_index = graph.add_node()
             graph.assign_meas_basis(node_index, default_meas_basis())
-            graph.add_physical_edge(node_index - width, node_index)
+            graph.add_edge(node_index - width, node_index)
             flow[node_index - width] = {node_index}
             node_indices_layer.append(node_index)
 
         for w in range(width - 1):
             if rng.random() < edge_p:
-                graph.add_physical_edge(node_indices_layer[w], node_indices_layer[w + 1])
+                graph.add_edge(node_indices_layer[w], node_indices_layer[w + 1])
 
     # output nodes
     for i in range(width):
-        node_index = graph.add_physical_node()
+        node_index = graph.add_node()
         graph.register_output(node_index, i)
-        graph.add_physical_edge(node_index - width, node_index)
+        graph.add_edge(node_index - width, node_index)
         flow[node_index - width] = {node_index}
 
     return graph, flow

--- a/graphqomb/schedule_solver.py
+++ b/graphqomb/schedule_solver.py
@@ -63,12 +63,12 @@ def _add_constraints(
                 model.add(node2meas[node] < node2meas[child])
 
     # A non-input, non-output node must be prepared before it is measured.
-    for node in graph.physical_nodes:
+    for node in graph.nodes:
         if node in node2prep and node in node2meas:
             model.add(node2prep[node] < node2meas[node])
 
     # Edge constraints
-    for node in graph.physical_nodes - set(graph.output_node_indices):
+    for node in graph.nodes - set(graph.output_node_indices):
         for neighbor in graph.neighbors(node):
             if neighbor in graph.input_node_indices:
                 if node in graph.input_node_indices:
@@ -114,7 +114,7 @@ def _compute_alive_nodes_at_time(
         Boolean variables indicating whether each node is alive at time t.
     """
     alive_at_t: list[cp_model.IntVar] = []
-    for node in ctx.graph.physical_nodes:
+    for node in ctx.graph.nodes:
         a_pre = ctx.model.new_bool_var(f"alive_pre_{node}_{t}")
         if node in ctx.graph.input_node_indices:
             ctx.model.add(a_pre == 1)
@@ -147,7 +147,7 @@ def _set_minimize_space_objective(
     max_time: int,
 ) -> None:
     """Set objective to minimize the maximum number of qubits used at any time."""
-    max_space = ctx.model.new_int_var(0, len(ctx.graph.physical_nodes), "max_space")
+    max_space = ctx.model.new_int_var(0, len(ctx.graph.nodes), "max_space")
     for t in range(max_time):
         alive_at_t = _compute_alive_nodes_at_time(ctx, node2prep, node2meas, t)
         ctx.model.add(max_space >= sum(alive_at_t))
@@ -208,12 +208,12 @@ def solve_schedule(
     model = cp_model.CpModel()
 
     # Determine max_time from config or calculate default
-    max_time = config.max_time if config.max_time is not None else 2 * len(graph.physical_nodes)
+    max_time = config.max_time if config.max_time is not None else 2 * len(graph.nodes)
 
     # Create variables
     node2prep: dict[int, cp_model.IntVar] = {}
     node2meas: dict[int, cp_model.IntVar] = {}
-    for node in graph.physical_nodes:
+    for node in graph.nodes:
         if node not in graph.input_node_indices:
             node2prep[node] = model.new_int_var(0, max_time, f"prep_{node}")
         if node not in graph.output_node_indices:

--- a/graphqomb/scheduler.py
+++ b/graphqomb/scheduler.py
@@ -232,12 +232,10 @@ class Scheduler:
         takes precedence, even when the value is ``None``.
         """
         self.prepare_time = {
-            node: prepare_time.get(node, None)
-            for node in self.graph.nodes - self.graph.input_node_indices.keys()
+            node: prepare_time.get(node, None) for node in self.graph.nodes - self.graph.input_node_indices.keys()
         }
         self.measure_time = {
-            node: measure_time.get(node, None)
-            for node in self.graph.nodes - self.graph.output_node_indices.keys()
+            node: measure_time.get(node, None) for node in self.graph.nodes - self.graph.output_node_indices.keys()
         }
         if entangle_time is not None:
             resolved_entangle_time: dict[tuple[int, int], int | None] = {}
@@ -555,12 +553,10 @@ class Scheduler:
 
         prepare_time, measure_time = result
         prep_time = {
-            node: prepare_time.get(node, None)
-            for node in self.graph.nodes - self.graph.input_node_indices.keys()
+            node: prepare_time.get(node, None) for node in self.graph.nodes - self.graph.input_node_indices.keys()
         }
         meas_time = {
-            node: measure_time.get(node, None)
-            for node in self.graph.nodes - self.graph.output_node_indices.keys()
+            node: measure_time.get(node, None) for node in self.graph.nodes - self.graph.output_node_indices.keys()
         }
 
         self.prepare_time = prep_time

--- a/graphqomb/scheduler.py
+++ b/graphqomb/scheduler.py
@@ -151,10 +151,10 @@ class Scheduler:
     ) -> None:
         self.graph = graph
         self.dag = dag_from_flow(graph, xflow, zflow)
-        self.prepare_time = dict.fromkeys(graph.physical_nodes - graph.input_node_indices.keys())
-        self.measure_time = dict.fromkeys(graph.physical_nodes - graph.output_node_indices.keys())
-        # Initialize entangle_time for all physical edges
-        self.entangle_time = dict.fromkeys(graph.physical_edges)
+        self.prepare_time = dict.fromkeys(graph.nodes - graph.input_node_indices.keys())
+        self.measure_time = dict.fromkeys(graph.nodes - graph.output_node_indices.keys())
+        # Initialize entangle_time for all edges
+        self.entangle_time = dict.fromkeys(graph.edges)
 
     def num_slices(self) -> int:
         r"""Return the number of slices in the schedule.
@@ -228,16 +228,16 @@ class Scheduler:
 
         The graph is treated as undirected. For convenience, `entangle_time` accepts edges
         in either order: both ``(u, v)`` and ``(v, u)`` are recognized. If both keys are
-        provided, the canonical order (as returned by :attr:`BaseGraphState.physical_edges`)
+        provided, the canonical order (as returned by :attr:`BaseGraphState.edges`)
         takes precedence, even when the value is ``None``.
         """
         self.prepare_time = {
             node: prepare_time.get(node, None)
-            for node in self.graph.physical_nodes - self.graph.input_node_indices.keys()
+            for node in self.graph.nodes - self.graph.input_node_indices.keys()
         }
         self.measure_time = {
             node: measure_time.get(node, None)
-            for node in self.graph.physical_nodes - self.graph.output_node_indices.keys()
+            for node in self.graph.nodes - self.graph.output_node_indices.keys()
         }
         if entangle_time is not None:
             resolved_entangle_time: dict[tuple[int, int], int | None] = {}
@@ -264,7 +264,7 @@ class Scheduler:
         """
         input_nodes = self.graph.input_node_indices.keys()
         output_nodes = self.graph.output_node_indices.keys()
-        physical_nodes = self.graph.physical_nodes
+        nodes = self.graph.nodes
 
         # Input nodes should not be in prepare_time
         invalid_prep = input_nodes & self.prepare_time.keys()
@@ -279,8 +279,8 @@ class Scheduler:
             raise ValueError(msg)
 
         # Check expected node sets
-        expected_prep_nodes = physical_nodes - input_nodes
-        expected_meas_nodes = physical_nodes - output_nodes
+        expected_prep_nodes = nodes - input_nodes
+        expected_meas_nodes = nodes - output_nodes
 
         if self.prepare_time.keys() != expected_prep_nodes:
             missing = expected_prep_nodes - self.prepare_time.keys()
@@ -376,7 +376,7 @@ class Scheduler:
         Only schedules entanglement for edges with `None` time. Preserves manually set times.
         Validation of measurement causality is performed by `validate_schedule()`.
         """
-        for edge in self.graph.physical_edges:
+        for edge in self.graph.edges:
             node1, node2 = edge
 
             # Get preparation times (input nodes are considered prepared at time -1)
@@ -556,11 +556,11 @@ class Scheduler:
         prepare_time, measure_time = result
         prep_time = {
             node: prepare_time.get(node, None)
-            for node in self.graph.physical_nodes - self.graph.input_node_indices.keys()
+            for node in self.graph.nodes - self.graph.input_node_indices.keys()
         }
         meas_time = {
             node: measure_time.get(node, None)
-            for node in self.graph.physical_nodes - self.graph.output_node_indices.keys()
+            for node in self.graph.nodes - self.graph.output_node_indices.keys()
         }
 
         self.prepare_time = prep_time

--- a/graphqomb/visualizer.py
+++ b/graphqomb/visualizer.py
@@ -306,9 +306,7 @@ def _calc_node_positions(graph: BaseGraphState) -> dict[int, tuple[float, float]
     # For internal nodes, use networkx layout to minimize crossings
     if internal_nodes:
         # Create subgraph of internal nodes and their connections
-        internal_edges = [
-            edge for edge in graph.edges if edge[0] in internal_nodes and edge[1] in internal_nodes
-        ]
+        internal_edges = [edge for edge in graph.edges if edge[0] in internal_nodes and edge[1] in internal_nodes]
 
         if internal_edges:
             # Use spring layout for internal nodes

--- a/graphqomb/visualizer.py
+++ b/graphqomb/visualizer.py
@@ -131,7 +131,7 @@ def visualize(  # noqa: PLR0913
     # Draw nodes with special handling for Pauli measurements
     pauli_nodes = _find_pauli_nodes(graph)
 
-    for node in graph.physical_nodes:
+    for node in graph.nodes:
         if node in pauli_nodes:
             # Calculate accurate patch radius for this specific position
             x, y = node_pos[node]
@@ -142,7 +142,7 @@ def visualize(  # noqa: PLR0913
             node_color = node_colors.get(node, ColorMap.OUTPUT)  # Default to output color
             ax.scatter(*node_pos[node], color=node_color, s=node_size, zorder=2)
 
-    for edge in graph.physical_edges:
+    for edge in graph.edges:
         x0, y0 = node_pos[edge[0]]
         x1, y1 = node_pos[edge[1]]
         ax.plot(
@@ -157,7 +157,7 @@ def visualize(  # noqa: PLR0913
         pauli_nodes = _find_pauli_nodes(graph)
 
         # Draw labels manually for better center alignment
-        for node in graph.physical_nodes:
+        for node in graph.nodes:
             x, y = node_pos[node]
 
             # All nodes now have the same size, so use same font size calculation
@@ -263,7 +263,7 @@ def _determine_node_positions(
             node_pos[node] = (coord[0], coord[1] if len(coord) >= _MIN_2D_COORDS else 0.0)
 
         # For nodes without coordinates, calculate positions
-        missing_nodes = graph.physical_nodes - node_pos.keys()
+        missing_nodes = graph.nodes - node_pos.keys()
         if missing_nodes:
             # Calculate auto positions for all nodes
             auto_pos = _calc_node_positions(graph)
@@ -290,7 +290,7 @@ def _calc_node_positions(graph: BaseGraphState) -> dict[int, tuple[float, float]
     dict[int, tuple[float, float]]
         Mapping of node indices to their (x, y) positions.
     """
-    internal_nodes = graph.physical_nodes - graph.input_node_indices.keys() - graph.output_node_indices.keys()
+    internal_nodes = graph.nodes - graph.input_node_indices.keys() - graph.output_node_indices.keys()
 
     pos: dict[int, tuple[float, float]] = {}
 
@@ -307,7 +307,7 @@ def _calc_node_positions(graph: BaseGraphState) -> dict[int, tuple[float, float]
     if internal_nodes:
         # Create subgraph of internal nodes and their connections
         internal_edges = [
-            edge for edge in graph.physical_edges if edge[0] in internal_nodes and edge[1] in internal_nodes
+            edge for edge in graph.edges if edge[0] in internal_nodes and edge[1] in internal_nodes
         ]
 
         if internal_edges:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -292,7 +292,7 @@ def test_circuit2graph_simple_circuit() -> None:
     assert len(graph.input_node_indices) == 2
     assert len(graph.output_node_indices) == 2
     # 2 input nodes + 2 J gate nodes = 4 total nodes
-    assert len(graph.physical_nodes) == 4
+    assert len(graph.nodes) == 4
 
     # Check gflow
     assert len(gflow) == 2  # Two J gates should have gflow
@@ -312,10 +312,10 @@ def test_circuit2graph_phase_gadget_circuit() -> None:
     assert len(graph.input_node_indices) == 3
     assert len(graph.output_node_indices) == 3
     # 3 input nodes + 1 phase gadget node = 4 total nodes
-    assert len(graph.physical_nodes) == 4
+    assert len(graph.nodes) == 4
 
     # Check phase gadget node has correct measurement basis
-    pg_nodes = [n for n in graph.physical_nodes if n not in graph.input_node_indices]
+    pg_nodes = [n for n in graph.nodes if n not in graph.input_node_indices]
     assert len(pg_nodes) == 1
     pg_node = pg_nodes[0]
     basis = graph.meas_bases[pg_node]
@@ -332,7 +332,7 @@ def test_circuit2graph_empty_circuit() -> None:
     # Check graph properties
     assert len(graph.input_node_indices) == 2
     assert len(graph.output_node_indices) == 2
-    assert len(graph.physical_nodes) == 2  # Only input/output nodes
+    assert len(graph.nodes) == 2  # Only input/output nodes
     assert len(gflow) == 0  # No gflow for empty circuit
 
     # Check scheduler
@@ -380,7 +380,7 @@ def test_circuit2graph_complex_circuit() -> None:
     assert len(graph.output_node_indices) == 4
 
     # Count nodes: 4 inputs + 4 J nodes + 1 phase gadget = 9
-    assert len(graph.physical_nodes) == 9
+    assert len(graph.nodes) == 9
 
     # Check gflow: 4 J gates + 1 phase gadget = 5 entries
     assert len(gflow) == 5
@@ -400,7 +400,7 @@ def test_circuit2graph_measurement_basis_assignment() -> None:
     # Find non-output nodes with measurement basis (J gates are applied to input nodes)
     measured_nodes = [
         (n, basis)
-        for n in graph.physical_nodes
+        for n in graph.nodes
         if n not in graph.output_node_indices and (basis := graph.meas_bases.get(n))
     ]
 
@@ -424,7 +424,7 @@ def test_circuit2graph_circuit_with_macro_gates() -> None:
     assert len(graph.input_node_indices) == 2
     assert len(graph.output_node_indices) == 2
     # H expands to 1 J, CNOT expands to 2 J + 1 CZ = 3 nodes total
-    assert len(graph.physical_nodes) == 5  # 2 inputs + 3 new nodes
+    assert len(graph.nodes) == 5  # 2 inputs + 3 new nodes
 
 
 # circuit2graph scheduling tests
@@ -494,7 +494,7 @@ def test_circuit2graph_phase_gadget_timing() -> None:
     graph, _gflow, scheduler = circuit2graph(circuit)
 
     # Check that phase gadget node has valid timing
-    pg_nodes = [n for n in graph.physical_nodes if graph.meas_bases.get(n) and graph.meas_bases[n].plane == Plane.YZ]
+    pg_nodes = [n for n in graph.nodes if graph.meas_bases.get(n) and graph.meas_bases[n].plane == Plane.YZ]
     assert len(pg_nodes) == 1
     assert scheduler.prepare_time.get(pg_nodes[0]) is not None
     assert scheduler.measure_time.get(pg_nodes[0]) is not None
@@ -638,7 +638,7 @@ def test_circuit2graph_single_qubit_no_gates() -> None:
 
     graph, gflow, scheduler = circuit2graph(circuit)
 
-    assert len(graph.physical_nodes) == 1
+    assert len(graph.nodes) == 1
     assert len(gflow) == 0
     assert isinstance(scheduler, Scheduler)
 
@@ -671,7 +671,7 @@ def test_circuit2graph_deep_circuit() -> None:
     scheduler.validate_schedule()
 
     # Check expected number of nodes: 2 input + 20 J gates
-    assert len(graph.physical_nodes) == 22
+    assert len(graph.nodes) == 22
 
 
 def test_circuit2graph_scheduler_can_resolve_with_different_strategy() -> None:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -399,9 +399,7 @@ def test_circuit2graph_measurement_basis_assignment() -> None:
 
     # Find non-output nodes with measurement basis (J gates are applied to input nodes)
     measured_nodes = [
-        (n, basis)
-        for n in graph.nodes
-        if n not in graph.output_node_indices and (basis := graph.meas_bases.get(n))
+        (n, basis) for n in graph.nodes if n not in graph.output_node_indices and (basis := graph.meas_bases.get(n))
     ]
 
     assert len(measured_nodes) == 2

--- a/tests/test_feedforward.py
+++ b/tests/test_feedforward.py
@@ -22,9 +22,9 @@ from graphqomb.graphstate import GraphState
 
 def two_node_graph() -> tuple[GraphState, int, int]:
     graphstate = GraphState()
-    node1 = graphstate.add_physical_node()
-    node2 = graphstate.add_physical_node()
-    graphstate.add_physical_edge(node1, node2)
+    node1 = graphstate.add_node()
+    node2 = graphstate.add_node()
+    graphstate.add_edge(node1, node2)
     return graphstate, node1, node2
 
 
@@ -155,11 +155,11 @@ def test_propagate_correction_map_xy_plane() -> None:
     """Test propagate_correction_map with XY plane measurement."""
     # Create a simple graph with 3 nodes: parent -> target -> child
     graphstate = GraphState()
-    parent = graphstate.add_physical_node()
-    target = graphstate.add_physical_node()
-    child = graphstate.add_physical_node()
-    graphstate.add_physical_edge(parent, target)
-    graphstate.add_physical_edge(target, child)
+    parent = graphstate.add_node()
+    target = graphstate.add_node()
+    child = graphstate.add_node()
+    graphstate.add_edge(parent, target)
+    graphstate.add_edge(target, child)
 
     # Set measurement basis for target node (XY plane)
     graphstate.assign_meas_basis(target, PlannerMeasBasis(Plane.XY, 0.0))
@@ -187,11 +187,11 @@ def test_propagate_correction_map_yz_plane() -> None:
     """Test propagate_correction_map with YZ plane measurement."""
     # Create a simple graph with 3 nodes: parent -> target -> child
     graphstate = GraphState()
-    parent = graphstate.add_physical_node()
-    target = graphstate.add_physical_node()
-    child = graphstate.add_physical_node()
-    graphstate.add_physical_edge(parent, target)
-    graphstate.add_physical_edge(target, child)
+    parent = graphstate.add_node()
+    target = graphstate.add_node()
+    child = graphstate.add_node()
+    graphstate.add_edge(parent, target)
+    graphstate.add_edge(target, child)
 
     # Set measurement basis for target node (YZ plane)
     graphstate.assign_meas_basis(target, PlannerMeasBasis(Plane.YZ, 0.0))
@@ -218,11 +218,11 @@ def test_propagate_correction_map_xz_plane() -> None:
     """Test propagate_correction_map with XZ plane measurement."""
     # Create a simple graph with 3 nodes: parent -> target -> child
     graphstate = GraphState()
-    parent = graphstate.add_physical_node()
-    target = graphstate.add_physical_node()
-    child = graphstate.add_physical_node()
-    graphstate.add_physical_edge(parent, target)
-    graphstate.add_physical_edge(target, child)
+    parent = graphstate.add_node()
+    target = graphstate.add_node()
+    child = graphstate.add_node()
+    graphstate.add_edge(parent, target)
+    graphstate.add_edge(target, child)
 
     # Set measurement basis for target node (XZ plane)
     graphstate.assign_meas_basis(target, PlannerMeasBasis(Plane.XZ, 0.0))
@@ -249,7 +249,7 @@ def test_propagate_correction_map_xz_plane() -> None:
 def test_propagate_correction_map_output_node_error() -> None:
     """Test that propagate_correction_map raises error for output nodes."""
     graphstate = GraphState()
-    node = graphstate.add_physical_node()
+    node = graphstate.add_node()
     graphstate.register_output(node, 0)
 
     xflow: dict[int, set[int]] = {node: set()}
@@ -263,11 +263,11 @@ def test_propagate_correction_map_zflow_none() -> None:
     """Test propagate_correction_map with zflow=None."""
     # Create a simple graph
     graphstate = GraphState()
-    parent = graphstate.add_physical_node()
-    target = graphstate.add_physical_node()
-    child = graphstate.add_physical_node()
-    graphstate.add_physical_edge(parent, target)
-    graphstate.add_physical_edge(target, child)
+    parent = graphstate.add_node()
+    target = graphstate.add_node()
+    child = graphstate.add_node()
+    graphstate.add_edge(parent, target)
+    graphstate.add_edge(target, child)
 
     # Set measurement basis
     graphstate.assign_meas_basis(target, PlannerMeasBasis(Plane.XY, 0.0))
@@ -296,11 +296,11 @@ def test_signal_shifting_simple() -> None:
     """Test signal_shifting on a simple graph."""
     # Create a linear graph: node0 -> node1 -> output
     graphstate = GraphState()
-    node0 = graphstate.add_physical_node()
-    node1 = graphstate.add_physical_node()
-    output = graphstate.add_physical_node()
-    graphstate.add_physical_edge(node0, node1)
-    graphstate.add_physical_edge(node1, output)
+    node0 = graphstate.add_node()
+    node1 = graphstate.add_node()
+    output = graphstate.add_node()
+    graphstate.add_edge(node0, node1)
+    graphstate.add_edge(node1, output)
 
     # Set measurement bases
     graphstate.assign_meas_basis(node0, PlannerMeasBasis(Plane.XY, 0.0))
@@ -325,11 +325,11 @@ def test_signal_shifting_zflow_none() -> None:
     """Test signal_shifting with zflow=None."""
     # Create a simple graph
     graphstate = GraphState()
-    node0 = graphstate.add_physical_node()
-    node1 = graphstate.add_physical_node()
-    output = graphstate.add_physical_node()
-    graphstate.add_physical_edge(node0, node1)
-    graphstate.add_physical_edge(node1, output)
+    node0 = graphstate.add_node()
+    node1 = graphstate.add_node()
+    output = graphstate.add_node()
+    graphstate.add_edge(node0, node1)
+    graphstate.add_edge(node1, output)
 
     # Set measurement bases
     graphstate.assign_meas_basis(node0, PlannerMeasBasis(Plane.XY, 0.0))
@@ -356,11 +356,11 @@ def test_pauli_simplification_x_axis_removes_x_correction() -> None:
     """Test that X-axis measurement removes X corrections from the flow."""
     # Create a 3-node graph: parent -> target -> output
     graphstate = GraphState()
-    parent = graphstate.add_physical_node()
-    target = graphstate.add_physical_node()
-    output = graphstate.add_physical_node()
-    graphstate.add_physical_edge(parent, target)
-    graphstate.add_physical_edge(target, output)
+    parent = graphstate.add_node()
+    target = graphstate.add_node()
+    output = graphstate.add_node()
+    graphstate.add_edge(parent, target)
+    graphstate.add_edge(target, output)
 
     # Set X-axis measurement basis for target
     graphstate.assign_meas_basis(target, AxisMeasBasis(Axis.X, Sign.PLUS))
@@ -384,11 +384,11 @@ def test_pauli_simplification_z_axis_removes_z_correction() -> None:
     """Test that Z-axis measurement removes Z corrections from the flow."""
     # Create a 3-node graph: parent -> target -> output
     graphstate = GraphState()
-    parent = graphstate.add_physical_node()
-    target = graphstate.add_physical_node()
-    output = graphstate.add_physical_node()
-    graphstate.add_physical_edge(parent, target)
-    graphstate.add_physical_edge(target, output)
+    parent = graphstate.add_node()
+    target = graphstate.add_node()
+    output = graphstate.add_node()
+    graphstate.add_edge(parent, target)
+    graphstate.add_edge(target, output)
 
     # Set Z-axis measurement basis for target
     graphstate.assign_meas_basis(target, AxisMeasBasis(Axis.Z, Sign.PLUS))
@@ -412,11 +412,11 @@ def test_pauli_simplification_y_axis_removes_both_corrections() -> None:
     """Test that Y-axis measurement removes both X and Z corrections from the flow."""
     # Create a 3-node graph: parent -> target -> output
     graphstate = GraphState()
-    parent = graphstate.add_physical_node()
-    target = graphstate.add_physical_node()
-    output = graphstate.add_physical_node()
-    graphstate.add_physical_edge(parent, target)
-    graphstate.add_physical_edge(target, output)
+    parent = graphstate.add_node()
+    target = graphstate.add_node()
+    output = graphstate.add_node()
+    graphstate.add_edge(parent, target)
+    graphstate.add_edge(target, output)
 
     # Set Y-axis measurement basis for target
     graphstate.assign_meas_basis(target, AxisMeasBasis(Axis.Y, Sign.PLUS))
@@ -439,11 +439,11 @@ def test_pauli_simplification_y_axis_skip() -> None:
     """Test that Y-axis measurement skips if not both corrections are present."""
     # Create a 3-node graph: parent -> target -> output
     graphstate = GraphState()
-    parent = graphstate.add_physical_node()
-    target = graphstate.add_physical_node()
-    output = graphstate.add_physical_node()
-    graphstate.add_physical_edge(parent, target)
-    graphstate.add_physical_edge(target, output)
+    parent = graphstate.add_node()
+    target = graphstate.add_node()
+    output = graphstate.add_node()
+    graphstate.add_edge(parent, target)
+    graphstate.add_edge(target, output)
 
     # Set Y-axis measurement basis for target
     graphstate.assign_meas_basis(target, AxisMeasBasis(Axis.Y, Sign.PLUS))
@@ -472,11 +472,11 @@ def test_pauli_simplification_non_pauli_leaves_unchanged() -> None:
     """Test that non-Pauli measurement angles leave corrections unchanged."""
     # Create a 3-node graph: parent -> target -> output
     graphstate = GraphState()
-    parent = graphstate.add_physical_node()
-    target = graphstate.add_physical_node()
-    output = graphstate.add_physical_node()
-    graphstate.add_physical_edge(parent, target)
-    graphstate.add_physical_edge(target, output)
+    parent = graphstate.add_node()
+    target = graphstate.add_node()
+    output = graphstate.add_node()
+    graphstate.add_edge(parent, target)
+    graphstate.add_edge(target, output)
 
     # Set non-Pauli measurement basis for target (XY plane, angle=pi/4)
     graphstate.assign_meas_basis(target, PlannerMeasBasis(Plane.XY, 0.25 * np.pi))
@@ -499,11 +499,11 @@ def test_pauli_simplification_preserves_original_flows() -> None:
     """Test that original xflow and zflow are not modified."""
     # Create a 3-node graph: parent -> target -> output
     graphstate = GraphState()
-    parent = graphstate.add_physical_node()
-    target = graphstate.add_physical_node()
-    output = graphstate.add_physical_node()
-    graphstate.add_physical_edge(parent, target)
-    graphstate.add_physical_edge(target, output)
+    parent = graphstate.add_node()
+    target = graphstate.add_node()
+    output = graphstate.add_node()
+    graphstate.add_edge(parent, target)
+    graphstate.add_edge(target, output)
 
     # Set X-axis measurement basis for target
     graphstate.assign_meas_basis(target, AxisMeasBasis(Axis.X, Sign.PLUS))

--- a/tests/test_focus_flow.py
+++ b/tests/test_focus_flow.py
@@ -21,9 +21,9 @@ def test_update_gflow_selects_minimal_node() -> None:
 
 def test_is_focused_true_for_focused_flow(graphstate: GraphState) -> None:
     """If a child is the same as its parent, the flow is focused."""
-    node1 = graphstate.add_physical_node()
-    node2 = graphstate.add_physical_node()
-    graphstate.add_physical_edge(node1, node2)
+    node1 = graphstate.add_node()
+    node2 = graphstate.add_node()
+    graphstate.add_edge(node1, node2)
     q_index = 0
     graphstate.register_input(node1, q_index)
     graphstate.register_output(node2, q_index)
@@ -34,11 +34,11 @@ def test_is_focused_true_for_focused_flow(graphstate: GraphState) -> None:
 
 def test_is_focused_false_for_unfocused_flow(graphstate: GraphState) -> None:
     """If a child differs from its parent, the flow is not focused."""
-    node1 = graphstate.add_physical_node()
-    node2 = graphstate.add_physical_node()
-    node3 = graphstate.add_physical_node()
-    graphstate.add_physical_edge(node1, node2)
-    graphstate.add_physical_edge(node2, node3)
+    node1 = graphstate.add_node()
+    node2 = graphstate.add_node()
+    node3 = graphstate.add_node()
+    graphstate.add_edge(node1, node2)
+    graphstate.add_edge(node2, node3)
     graphstate.assign_meas_basis(node1, default_meas_basis())
     graphstate.assign_meas_basis(node2, default_meas_basis())
     flow = {node1: node2, node2: node3}

--- a/tests/test_graph_compose.py
+++ b/tests/test_graph_compose.py
@@ -27,7 +27,7 @@ def create_simple_graph(input_qindices: list[int], output_qindices: list[int]) -
 
     input_nodes: list[int] = []
     for q_index in input_qindices:
-        node: int = graph.add_physical_node()
+        node: int = graph.add_node()
         graph.register_input(node, q_index)
         # All non-output nodes need measurement basis for canonical form
         graph.assign_meas_basis(node, PlannerMeasBasis(Plane.XY, 0.0))
@@ -35,7 +35,7 @@ def create_simple_graph(input_qindices: list[int], output_qindices: list[int]) -
 
     output_nodes: list[int] = []
     for q_index in output_qindices:
-        output_node: int = graph.add_physical_node()
+        output_node: int = graph.add_node()
         graph.register_output(output_node, q_index)
         # Output nodes don't need measurement basis
         output_nodes.append(output_node)
@@ -43,7 +43,7 @@ def create_simple_graph(input_qindices: list[int], output_qindices: list[int]) -
     # Add edges between input and output nodes
     for i, input_node in enumerate(input_nodes):
         if i < len(output_nodes):
-            graph.add_physical_edge(input_node, output_nodes[i])
+            graph.add_edge(input_node, output_nodes[i])
 
     return graph
 
@@ -91,6 +91,41 @@ def test_compose_no_common_qindex() -> None:
     assert set(composed.output_node_indices.values()) == expected_output_qindices
 
 
+def test_compose_with_non_contiguous_explicit_node_ids() -> None:
+    """Test compose remaps sparse source node ids consistently."""
+    graph1 = GraphState()
+    g1_in = graph1.add_node(10, coordinate=(1.0, 0.0))
+    g1_out = graph1.add_node(30, coordinate=(3.0, 0.0))
+    graph1.add_edge(g1_in, g1_out)
+    graph1.register_input(g1_in, 0)
+    graph1.register_output(g1_out, 1)
+    graph1.assign_meas_basis(g1_in, PlannerMeasBasis(Plane.XY, 0.0))
+
+    graph2 = GraphState()
+    g2_in = graph2.add_node(100, coordinate=(10.0, 0.0))
+    g2_mid = graph2.add_node(300, coordinate=(30.0, 0.0))
+    g2_out = graph2.add_node(500, coordinate=(50.0, 0.0))
+    graph2.add_edge(g2_in, g2_mid)
+    graph2.add_edge(g2_mid, g2_out)
+    graph2.register_input(g2_in, 1)
+    graph2.register_output(g2_out, 2)
+    graph2.assign_meas_basis(g2_in, PlannerMeasBasis(Plane.XY, 0.0))
+    graph2.assign_meas_basis(g2_mid, PlannerMeasBasis(Plane.XY, 0.0))
+
+    composed, node_map1, node_map2 = compose(graph1, graph2)
+
+    assert node_map1[g1_out] == node_map2[g2_in]
+    assert composed.input_node_indices == {node_map1[g1_in]: 0}
+    assert composed.output_node_indices == {node_map2[g2_out]: 2}
+    assert composed.has_edge(node_map1[g1_in], node_map2[g2_in])
+    assert composed.has_edge(node_map2[g2_in], node_map2[g2_mid])
+    assert composed.has_edge(node_map2[g2_mid], node_map2[g2_out])
+    assert composed.coordinates[node_map1[g1_in]] == (1.0, 0.0)
+    assert composed.coordinates[node_map2[g2_in]] == (10.0, 0.0)
+    assert composed.coordinates[node_map2[g2_mid]] == (30.0, 0.0)
+    assert composed.coordinates[node_map2[g2_out]] == (50.0, 0.0)
+
+
 def test_compose_qindex_conflict() -> None:
     """Test compose function raises error for qindex conflicts."""
     # Create graph1: input [0] -> output [1]
@@ -107,23 +142,23 @@ def test_compose_qindex_conflict() -> None:
 def test_compose_preserves_measurement_bases() -> None:
     """Test that measurement bases are preserved during composition."""
     graph1: GraphState = GraphState()
-    node1: int = graph1.add_physical_node()
+    node1: int = graph1.add_node()
     graph1.register_input(node1, 0)
     # Non-output nodes need measurement basis
     graph1.assign_meas_basis(node1, PlannerMeasBasis(Plane.XY, 0.0))
 
-    node2: int = graph1.add_physical_node()
+    node2: int = graph1.add_node()
     graph1.register_output(node2, 1)
     meas_basis: PlannerMeasBasis = PlannerMeasBasis(Plane.XY, 0.5)
     graph1.assign_meas_basis(node2, meas_basis)
 
     graph2: GraphState = GraphState()
-    node3: int = graph2.add_physical_node()
+    node3: int = graph2.add_node()
     graph2.register_input(node3, 2)
     # Non-output nodes need measurement basis
     graph2.assign_meas_basis(node3, PlannerMeasBasis(Plane.XY, 0.0))
 
-    node4: int = graph2.add_physical_node()
+    node4: int = graph2.add_node()
     graph2.register_output(node4, 3)
 
     composed: BaseGraphState
@@ -175,6 +210,6 @@ def test_compose_empty_connection() -> None:
     assert set(composed.output_node_indices.values()) == expected_output_qindices
 
     # Check that all nodes and edges are preserved
-    total_original_nodes: int = len(graph1.physical_nodes) + len(graph2.physical_nodes)
+    total_original_nodes: int = len(graph1.nodes) + len(graph2.nodes)
     # No nodes should be excluded since no connections are made
-    assert len(composed.physical_nodes) == total_original_nodes
+    assert len(composed.nodes) == total_original_nodes

--- a/tests/test_graphstate.py
+++ b/tests/test_graphstate.py
@@ -26,8 +26,8 @@ def graph() -> GraphState:
 @pytest.fixture
 def canonical_graph() -> GraphState:
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
@@ -36,16 +36,63 @@ def canonical_graph() -> GraphState:
     return graph
 
 
-def test_add_physical_node(graph: GraphState) -> None:
-    """Test adding a physical node to the graph."""
-    node_index = graph.add_physical_node()
-    assert node_index in graph.physical_nodes
-    assert len(graph.physical_nodes) == 1
+def test_add_node(graph: GraphState) -> None:
+    """Test adding a node to the graph."""
+    node_index = graph.add_node()
+    assert node_index in graph.nodes
+    assert len(graph.nodes) == 1
 
 
-def test_add_physical_node_input_output(graph: GraphState) -> None:
-    """Test adding a physical node as input and output."""
-    node_index = graph.add_physical_node()
+def test_standard_graph_api_adds_nodes_and_edges(graph: GraphState) -> None:
+    """Test the standard graph-style node and edge API."""
+    node0 = graph.add_node(coordinate=(1.0, 2.0))
+    node10 = graph.add_node(10)
+    node11 = graph.add_node()
+
+    assert node0 == 0
+    assert node10 == 10
+    assert node11 == 11
+    assert graph.nodes == {0, 10, 11}
+    assert graph.number_of_nodes() == 3
+    assert graph.has_node(10)
+    assert not graph.has_node(9)
+    assert graph.coordinates == {0: (1.0, 2.0)}
+
+    graph.add_edge(node0, node10)
+    graph.add_edge(node10, node11)
+
+    assert graph.edges == {(0, 10), (10, 11)}
+    assert graph.number_of_edges() == 2
+    assert graph.has_edge(node10, node0)
+    assert not graph.has_edge(node0, node11)
+
+
+def test_standard_graph_api_rejects_duplicate_node(graph: GraphState) -> None:
+    """Test that add_node rejects an existing explicit node id."""
+    graph.add_node(5)
+    with pytest.raises(ValueError, match="Node already exists node=5"):
+        graph.add_node(5)
+
+
+def test_standard_graph_api_remove_node_cleans_metadata(graph: GraphState) -> None:
+    """Test remove_node removes incident edges and node metadata."""
+    node0 = graph.add_node(coordinate=(1.0, 2.0))
+    node1 = graph.add_node(coordinate=(3.0, 4.0))
+    graph.add_edge(node0, node1)
+    graph.register_output(node1, 0)
+    graph.assign_meas_basis(node0, PlannerMeasBasis(Plane.XY, 0.0))
+
+    graph.remove_node(node0)
+
+    assert graph.nodes == {node1}
+    assert graph.edges == set()
+    assert node0 not in graph.meas_bases
+    assert graph.coordinates == {node1: (3.0, 4.0)}
+
+
+def test_add_node_input_output(graph: GraphState) -> None:
+    """Test adding a node as input and output."""
+    node_index = graph.add_node()
     q_index = 0
     graph.register_input(node_index, q_index)
     graph.register_output(node_index, q_index)
@@ -63,122 +110,122 @@ def test_ensure_node_exists_raises(graph: GraphState) -> None:
 
 def test_ensure_node_exists(graph: GraphState) -> None:
     """Test ensuring a node exists in the graph."""
-    node_index = graph.add_physical_node()
+    node_index = graph.add_node()
     graph._ensure_node_exists(node_index)
 
 
 def test_neighbors(graph: GraphState) -> None:
     """Test getting the neighbors of a node in the graph."""
-    node_index1 = graph.add_physical_node()
-    node_index2 = graph.add_physical_node()
-    node_index3 = graph.add_physical_node()
-    graph.add_physical_edge(node_index1, node_index2)
-    graph.add_physical_edge(node_index2, node_index3)
+    node_index1 = graph.add_node()
+    node_index2 = graph.add_node()
+    node_index3 = graph.add_node()
+    graph.add_edge(node_index1, node_index2)
+    graph.add_edge(node_index2, node_index3)
     assert graph.neighbors(node_index1) == {node_index2}
     assert graph.neighbors(node_index2) == {node_index1, node_index3}
     assert graph.neighbors(node_index3) == {node_index2}
 
 
-def test_add_physical_edge(graph: GraphState) -> None:
-    """Test adding a physical edge to the graph."""
-    node_index1 = graph.add_physical_node()
-    node_index2 = graph.add_physical_node()
-    graph.add_physical_edge(node_index1, node_index2)
-    assert (node_index1, node_index2) in graph.physical_edges or (node_index2, node_index1) in graph.physical_edges
-    assert len(graph.physical_edges) == 1
+def test_add_edge(graph: GraphState) -> None:
+    """Test adding an edge to the graph."""
+    node_index1 = graph.add_node()
+    node_index2 = graph.add_node()
+    graph.add_edge(node_index1, node_index2)
+    assert (node_index1, node_index2) in graph.edges or (node_index2, node_index1) in graph.edges
+    assert len(graph.edges) == 1
 
 
-def test_add_duplicate_physical_edge(graph: GraphState) -> None:
-    """Test adding a duplicate physical edge to the graph."""
-    node_index1 = graph.add_physical_node()
-    node_index2 = graph.add_physical_node()
-    graph.add_physical_edge(node_index1, node_index2)
+def test_add_duplicate_edge(graph: GraphState) -> None:
+    """Test adding a duplicate edge to the graph."""
+    node_index1 = graph.add_node()
+    node_index2 = graph.add_node()
+    graph.add_edge(node_index1, node_index2)
     with pytest.raises(ValueError, match=f"Edge already exists node1={node_index1}, node2={node_index2}"):
-        graph.add_physical_edge(node_index1, node_index2)
+        graph.add_edge(node_index1, node_index2)
 
 
 def test_add_edge_with_nonexistent_node(graph: GraphState) -> None:
     """Test adding an edge with a nonexistent node to the graph."""
-    node_index1 = graph.add_physical_node()
+    node_index1 = graph.add_node()
     with pytest.raises(ValueError, match="Node does not exist node=2"):
-        graph.add_physical_edge(node_index1, 2)
+        graph.add_edge(node_index1, 2)
 
 
-def test_remove_physical_node_with_nonexistent_node(graph: GraphState) -> None:
-    """Test removing a nonexistent physical node from the graph."""
+def test_remove_node_with_nonexistent_node(graph: GraphState) -> None:
+    """Test removing a nonexistent node from the graph."""
     with pytest.raises(ValueError, match="Node does not exist node=1"):
-        graph.remove_physical_node(1)
+        graph.remove_node(1)
 
 
-def test_remove_physical_node_with_input_removal(graph: GraphState) -> None:
+def test_remove_node_with_input_removal(graph: GraphState) -> None:
     """Test removing an input node from the graph"""
-    node_index = graph.add_physical_node()
+    node_index = graph.add_node()
     graph.register_input(node_index, 0)
     with pytest.raises(ValueError, match="The input node cannot be removed"):
-        graph.remove_physical_node(node_index)
+        graph.remove_node(node_index)
 
 
-def test_remove_physical_node(graph: GraphState) -> None:
-    """Test removing a physical node from the graph."""
-    node_index = graph.add_physical_node()
-    graph.remove_physical_node(node_index)
-    assert node_index not in graph.physical_nodes
-    assert len(graph.physical_nodes) == 0
+def test_remove_node(graph: GraphState) -> None:
+    """Test removing a node from the graph."""
+    node_index = graph.add_node()
+    graph.remove_node(node_index)
+    assert node_index not in graph.nodes
+    assert len(graph.nodes) == 0
 
 
-def test_remove_physical_node_from_minimal_graph(graph: GraphState) -> None:
-    """Test removing a physical node from the graph with edges."""
-    node_index1 = graph.add_physical_node()
-    node_index2 = graph.add_physical_node()
-    graph.add_physical_edge(node_index1, node_index2)
-    graph.remove_physical_node(node_index1)
-    assert node_index1 not in graph.physical_nodes
-    assert node_index2 in graph.physical_nodes
-    assert len(graph.physical_nodes) == 1
-    assert len(graph.physical_edges) == 0
+def test_remove_node_from_minimal_graph(graph: GraphState) -> None:
+    """Test removing a node from the graph with edges."""
+    node_index1 = graph.add_node()
+    node_index2 = graph.add_node()
+    graph.add_edge(node_index1, node_index2)
+    graph.remove_node(node_index1)
+    assert node_index1 not in graph.nodes
+    assert node_index2 in graph.nodes
+    assert len(graph.nodes) == 1
+    assert len(graph.edges) == 0
 
 
-def test_remove_physical_node_from_3_nodes_graph(graph: GraphState) -> None:
-    """Test removing a physical node from the graph with 3 nodes and edges."""
-    node_index1 = graph.add_physical_node()
-    node_index2 = graph.add_physical_node()
-    node_index3 = graph.add_physical_node()
-    graph.add_physical_edge(node_index1, node_index2)
-    graph.add_physical_edge(node_index2, node_index3)
+def test_remove_node_from_3_nodes_graph(graph: GraphState) -> None:
+    """Test removing a node from the graph with 3 nodes and edges."""
+    node_index1 = graph.add_node()
+    node_index2 = graph.add_node()
+    node_index3 = graph.add_node()
+    graph.add_edge(node_index1, node_index2)
+    graph.add_edge(node_index2, node_index3)
     q_index = 0
     graph.register_input(node_index1, q_index)
     graph.register_output(node_index3, q_index)
-    graph.remove_physical_node(node_index2)
-    assert graph.physical_nodes == {node_index1, node_index3}
-    assert len(graph.physical_nodes) == 2
-    assert len(graph.physical_edges) == 0
+    graph.remove_node(node_index2)
+    assert graph.nodes == {node_index1, node_index3}
+    assert len(graph.nodes) == 2
+    assert len(graph.edges) == 0
     assert graph.input_node_indices == {node_index1: q_index}
     assert graph.output_node_indices == {node_index3: q_index}
 
 
-def test_remove_physical_edge_with_nonexistent_nodes(graph: GraphState) -> None:
+def test_remove_edge_with_nonexistent_nodes(graph: GraphState) -> None:
     """Test removing an edge with nonexistent nodes from the graph."""
     with pytest.raises(ValueError, match="Node does not exist"):
-        graph.remove_physical_edge(1, 2)
+        graph.remove_edge(1, 2)
 
 
-def test_remove_physical_edge_with_nonexistent_edge(graph: GraphState) -> None:
+def test_remove_edge_with_nonexistent_edge(graph: GraphState) -> None:
     """Test removing a nonexistent edge from the graph."""
-    node_index1 = graph.add_physical_node()
-    node_index2 = graph.add_physical_node()
+    node_index1 = graph.add_node()
+    node_index2 = graph.add_node()
     with pytest.raises(ValueError, match="Edge does not exist"):
-        graph.remove_physical_edge(node_index1, node_index2)
+        graph.remove_edge(node_index1, node_index2)
 
 
-def test_remove_physical_edge(graph: GraphState) -> None:
-    """Test removing a physical edge from the graph."""
-    node_index1 = graph.add_physical_node()
-    node_index2 = graph.add_physical_node()
-    graph.add_physical_edge(node_index1, node_index2)
-    graph.remove_physical_edge(node_index1, node_index2)
-    assert (node_index1, node_index2) not in graph.physical_edges
-    assert (node_index2, node_index1) not in graph.physical_edges
-    assert len(graph.physical_edges) == 0
+def test_remove_edge(graph: GraphState) -> None:
+    """Test removing an edge from the graph."""
+    node_index1 = graph.add_node()
+    node_index2 = graph.add_node()
+    graph.add_edge(node_index1, node_index2)
+    graph.remove_edge(node_index1, node_index2)
+    assert (node_index1, node_index2) not in graph.edges
+    assert (node_index2, node_index1) not in graph.edges
+    assert len(graph.edges) == 0
 
 
 def test_register_output_raises_1(graph: GraphState) -> None:
@@ -187,8 +234,8 @@ def test_register_output_raises_1(graph: GraphState) -> None:
 
 
 def test_assign_meas_basis(graph: GraphState) -> None:
-    """Test setting the measurement basis of a physical node."""
-    node_index = graph.add_physical_node()
+    """Test setting the measurement basis of a node."""
+    node_index = graph.add_node()
     meas_basis = PlannerMeasBasis(Plane.XZ, 0.5 * math.pi)
     graph.assign_meas_basis(node_index, meas_basis)
     assert graph.meas_bases[node_index].plane == Plane.XZ
@@ -202,7 +249,7 @@ def test_check_canonical_form_true(canonical_graph: GraphState) -> None:
 
 def test_check_canonical_form_input_output_mismatch(canonical_graph: GraphState) -> None:
     """Test if the graph is in canonical form with input-output mismatch."""
-    node_index = canonical_graph.add_physical_node()
+    node_index = canonical_graph.add_node()
     canonical_graph.register_input(node_index, 1)
     canonical_graph.assign_meas_basis(node_index, PlannerMeasBasis(Plane.XY, 0.5 * np.pi))
     # The current implementation does not check input-output mismatch, so the test should pass
@@ -229,7 +276,7 @@ def test_check_canonical_form_with_local_clifford_expansion_true(canonical_graph
 
 def test_check_canonical_form_missing_meas_basis_false(canonical_graph: GraphState) -> None:
     """Test if the graph is in canonical form with missing measurement basis."""
-    _ = canonical_graph.add_physical_node()
+    _ = canonical_graph.add_node()
     with pytest.raises(ValueError, match="All non-output nodes must have measurement basis"):
         canonical_graph.check_canonical_form()
 
@@ -242,7 +289,7 @@ def test_check_canonical_form_empty_graph_is_true() -> None:
 
 def test_check_meas_raises_value_error(graph: GraphState) -> None:
     """Test if measurement planes and angles are set improperly."""
-    node_index = graph.add_physical_node()
+    node_index = graph.add_node()
     with pytest.raises(ValueError, match=f"Measurement basis not set for node {node_index}"):
         graph._check_meas_basis()
 
@@ -250,15 +297,15 @@ def test_check_meas_raises_value_error(graph: GraphState) -> None:
 def test_check_meas_basis_success(graph: GraphState) -> None:
     """Test if measurement planes and angles are set properly."""
     graph._check_meas_basis()
-    node_index1 = graph.add_physical_node()
+    node_index1 = graph.add_node()
     q_index = 0
     graph.register_input(node_index1, q_index)
     meas_basis = PlannerMeasBasis(Plane.XY, 0.5 * np.pi)
     graph.assign_meas_basis(node_index1, meas_basis)
     graph._check_meas_basis()
 
-    node_index2 = graph.add_physical_node()
-    graph.add_physical_edge(node_index1, node_index2)
+    node_index2 = graph.add_node()
+    graph.add_edge(node_index1, node_index2)
     graph.register_output(node_index2, q_index)
     graph._check_meas_basis()
 
@@ -277,13 +324,13 @@ def test_odd_neighbors(graph: GraphState) -> None:
          \   /
          node3
     """
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    node3 = graph.add_physical_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    node3 = graph.add_node()
 
-    graph.add_physical_edge(node1, node2)
-    graph.add_physical_edge(node2, node3)
-    graph.add_physical_edge(node3, node1)
+    graph.add_edge(node1, node2)
+    graph.add_edge(node2, node3)
+    graph.add_edge(node3, node1)
 
     assert odd_neighbors({node1}, graph) == {node2, node3}
     assert odd_neighbors({node1, node2}, graph) == {node1, node2}
@@ -294,7 +341,7 @@ def test_odd_neighbors(graph: GraphState) -> None:
 
 def test_set_coordinate(graph: GraphState) -> None:
     """Test setting coordinates for a node."""
-    node = graph.add_physical_node()
+    node = graph.add_node()
     graph.set_coordinate(node, (1.0, 2.0))
     assert graph.coordinates == {node: (1.0, 2.0)}
 
@@ -307,28 +354,28 @@ def test_set_coordinate_invalid_node(graph: GraphState) -> None:
 
 def test_set_coordinate_3d(graph: GraphState) -> None:
     """Test setting 3D coordinates for a node."""
-    node = graph.add_physical_node()
+    node = graph.add_node()
     graph.set_coordinate(node, (1.0, 2.0, 3.0))
     assert graph.coordinates == {node: (1.0, 2.0, 3.0)}
 
 
-def test_add_physical_node_with_coordinate() -> None:
+def test_add_node_with_coordinate() -> None:
     """Test adding a node with coordinates."""
     graph = GraphState()
-    node = graph.add_physical_node(coordinate=(1.5, 2.5))
+    node = graph.add_node(coordinate=(1.5, 2.5))
     assert graph.coordinates == {node: (1.5, 2.5)}
 
 
-def test_remove_physical_node_removes_coordinate() -> None:
+def test_remove_node_removes_coordinate() -> None:
     """Test that removing a node also removes its coordinate."""
     graph = GraphState()
-    node1 = graph.add_physical_node(coordinate=(1.0, 2.0))
-    node2 = graph.add_physical_node(coordinate=(3.0, 4.0))
-    graph.add_physical_edge(node1, node2)
+    node1 = graph.add_node(coordinate=(1.0, 2.0))
+    node2 = graph.add_node(coordinate=(3.0, 4.0))
+    graph.add_edge(node1, node2)
     graph.register_output(node2, 0)
     graph.assign_meas_basis(node1, PlannerMeasBasis(Plane.XY, 0.0))
 
-    graph.remove_physical_node(node1)
+    graph.remove_node(node1)
     assert node1 not in graph.coordinates
     assert graph.coordinates == {node2: (3.0, 4.0)}
 
@@ -349,9 +396,9 @@ def test_from_graph_with_coordinates() -> None:
 def test_from_base_graph_state_copies_coordinates() -> None:
     """Test that from_base_graph_state copies coordinates."""
     graph1 = GraphState()
-    node1 = graph1.add_physical_node(coordinate=(1.0, 2.0))
-    node2 = graph1.add_physical_node(coordinate=(3.0, 4.0))
-    graph1.add_physical_edge(node1, node2)
+    node1 = graph1.add_node(coordinate=(1.0, 2.0))
+    node2 = graph1.add_node(coordinate=(3.0, 4.0))
+    graph1.add_edge(node1, node2)
     graph1.register_input(node1, 0)
     graph1.register_output(node2, 0)
     graph1.assign_meas_basis(node1, PlannerMeasBasis(Plane.XY, 0.0))
@@ -366,18 +413,18 @@ def test_compose_copies_coordinates() -> None:
     """Test that compose copies coordinates from both graphs."""
     # Create first graph with coordinates
     graph1 = GraphState()
-    g1_in = graph1.add_physical_node(coordinate=(0.0, 0.0))
-    g1_out = graph1.add_physical_node(coordinate=(1.0, 0.0))
-    graph1.add_physical_edge(g1_in, g1_out)
+    g1_in = graph1.add_node(coordinate=(0.0, 0.0))
+    g1_out = graph1.add_node(coordinate=(1.0, 0.0))
+    graph1.add_edge(g1_in, g1_out)
     graph1.register_input(g1_in, 0)
     graph1.register_output(g1_out, 0)
     graph1.assign_meas_basis(g1_in, PlannerMeasBasis(Plane.XY, 0.0))
 
     # Create second graph with coordinates
     graph2 = GraphState()
-    g2_in = graph2.add_physical_node(coordinate=(2.0, 0.0))
-    g2_out = graph2.add_physical_node(coordinate=(3.0, 0.0))
-    graph2.add_physical_edge(g2_in, g2_out)
+    g2_in = graph2.add_node(coordinate=(2.0, 0.0))
+    g2_out = graph2.add_node(coordinate=(3.0, 0.0))
+    graph2.add_edge(g2_in, g2_out)
     graph2.register_input(g2_in, 0)
     graph2.register_output(g2_out, 0)
     graph2.assign_meas_basis(g2_in, PlannerMeasBasis(Plane.XY, 0.0))

--- a/tests/test_graphstate.py
+++ b/tests/test_graphstate.py
@@ -144,6 +144,13 @@ def test_add_duplicate_edge(graph: GraphState) -> None:
         graph.add_edge(node_index1, node_index2)
 
 
+def test_add_edge_rejects_self_loop(graph: GraphState) -> None:
+    """Test that adding a self-loop edge raises an error."""
+    node_index = graph.add_node()
+    with pytest.raises(ValueError, match="Self-loops are not allowed"):
+        graph.add_edge(node_index, node_index)
+
+
 def test_add_edge_with_nonexistent_node(graph: GraphState) -> None:
     """Test adding an edge with a nonexistent node to the graph."""
     node_index1 = graph.add_node()

--- a/tests/test_graphstate_bulk_init.py
+++ b/tests/test_graphstate_bulk_init.py
@@ -18,8 +18,8 @@ def test_from_graph_with_string_nodes() -> None:
     gs, node_map = GraphState.from_graph(nodes=nodes, edges=edges)
 
     assert node_map == {"start": 0, "middle": 1, "end": 2}
-    assert gs.physical_nodes == {0, 1, 2}
-    assert gs.physical_edges == {(0, 1), (1, 2)}
+    assert gs.nodes == {0, 1, 2}
+    assert gs.edges == {(0, 1), (1, 2)}
 
 
 def test_from_graph_with_tuple_nodes() -> None:
@@ -35,8 +35,8 @@ def test_from_graph_with_tuple_nodes() -> None:
     gs, node_map = GraphState.from_graph(nodes=grid_nodes, edges=grid_edges)
 
     assert len(node_map) == 4
-    assert gs.physical_nodes == {0, 1, 2, 3}
-    assert len(gs.physical_edges) == 4
+    assert gs.nodes == {0, 1, 2, 3}
+    assert len(gs.edges) == 4
 
 
 def test_from_graph_with_int_nodes() -> None:
@@ -47,7 +47,7 @@ def test_from_graph_with_int_nodes() -> None:
     gs, node_map = GraphState.from_graph(nodes=nodes, edges=edges)
 
     assert node_map == {10: 0, 20: 1, 30: 2}
-    assert gs.physical_nodes == {0, 1, 2}
+    assert gs.nodes == {0, 1, 2}
 
 
 def test_from_graph_with_inputs_outputs() -> None:
@@ -154,8 +154,8 @@ def test_from_graph_empty_nodes() -> None:
     gs, node_map = GraphState.from_graph(nodes=nodes, edges=edges)
 
     assert node_map == {}
-    assert gs.physical_nodes == set()
-    assert gs.physical_edges == set()
+    assert gs.nodes == set()
+    assert gs.edges == set()
 
 
 def test_from_graph_single_node() -> None:
@@ -163,18 +163,18 @@ def test_from_graph_single_node() -> None:
     gs, node_map = GraphState.from_graph(nodes=["a"], edges=[])
 
     assert node_map == {"a": 0}
-    assert gs.physical_nodes == {0}
+    assert gs.nodes == {0}
 
 
 def test_from_base_graph_state_simple() -> None:
     """Test from_base_graph_state() basic copying."""
     # Create source graph
     src = GraphState()
-    n0 = src.add_physical_node()
-    n1 = src.add_physical_node()
-    n2 = src.add_physical_node()
-    src.add_physical_edge(n0, n1)
-    src.add_physical_edge(n1, n2)
+    n0 = src.add_node()
+    n1 = src.add_node()
+    n2 = src.add_node()
+    src.add_edge(n0, n1)
+    src.add_edge(n1, n2)
     src.register_input(n0, 0)
     src.register_output(n2, 0)
     src.assign_meas_basis(n0, PlannerMeasBasis(Plane.XY, 0.0))
@@ -184,8 +184,8 @@ def test_from_base_graph_state_simple() -> None:
     dst, node_map = GraphState.from_base_graph_state(src)
 
     assert node_map == {0: 0, 1: 1, 2: 2}
-    assert dst.physical_nodes == {0, 1, 2}
-    assert dst.physical_edges == {(0, 1), (1, 2)}
+    assert dst.nodes == {0, 1, 2}
+    assert dst.edges == {(0, 1), (1, 2)}
     assert dst.input_node_indices == {0: 0}
     assert dst.output_node_indices == {2: 0}
     # Check measurement bases
@@ -201,8 +201,8 @@ def test_from_base_graph_state_preserves_indices() -> None:
     """Test from_base_graph_state() preserves qubit indices."""
     # Create source graph with custom qubit indices
     src = GraphState()
-    n0 = src.add_physical_node()
-    n1 = src.add_physical_node()
+    n0 = src.add_node()
+    n1 = src.add_node()
     src.register_input(n0, 5)
     src.register_output(n1, 10)
 
@@ -217,17 +217,17 @@ def test_from_base_graph_state_independence() -> None:
     """Test that modifications to copied graph don't affect original."""
     # Create source graph
     src = GraphState()
-    src.add_physical_node()
-    src.add_physical_node()
+    src.add_node()
+    src.add_node()
 
     # Copy the graph
     dst, _ = GraphState.from_base_graph_state(src)
 
     # Modify copied graph
-    dst.add_physical_node()
+    dst.add_node()
 
-    assert len(src.physical_nodes) == 2
-    assert len(dst.physical_nodes) == 3
+    assert len(src.nodes) == 2
+    assert len(dst.nodes) == 3
 
 
 def test_from_base_graph_state_empty() -> None:
@@ -236,8 +236,8 @@ def test_from_base_graph_state_empty() -> None:
     dst, node_map = GraphState.from_base_graph_state(src)
 
     assert node_map == {}
-    assert dst.physical_nodes == set()
-    assert dst.physical_edges == set()
+    assert dst.nodes == set()
+    assert dst.edges == set()
 
 
 def test_from_graph_with_complex_structure() -> None:
@@ -260,7 +260,7 @@ def test_from_graph_with_complex_structure() -> None:
     assert len(node_map) == 5
     assert gs.input_node_indices == {node_map["n1"]: 0}
     assert gs.output_node_indices == {node_map["n5"]: 0}
-    assert len(gs.physical_edges) == 5
+    assert len(gs.edges) == 5
 
 
 def test_from_graph_preserves_node_order() -> None:
@@ -278,13 +278,13 @@ def test_from_base_graph_state_with_complex_graph() -> None:
     """Test from_base_graph_state() with a complex graph."""
     # Create source graph with multiple components
     src = GraphState()
-    nodes = [src.add_physical_node() for _ in range(5)]
+    nodes = [src.add_node() for _ in range(5)]
 
     # Add edges to create a specific structure
-    src.add_physical_edge(nodes[0], nodes[1])
-    src.add_physical_edge(nodes[1], nodes[2])
-    src.add_physical_edge(nodes[2], nodes[3])
-    src.add_physical_edge(nodes[3], nodes[4])
+    src.add_edge(nodes[0], nodes[1])
+    src.add_edge(nodes[1], nodes[2])
+    src.add_edge(nodes[2], nodes[3])
+    src.add_edge(nodes[3], nodes[4])
 
     # Register some inputs and outputs
     src.register_input(nodes[0], 0)
@@ -300,7 +300,7 @@ def test_from_base_graph_state_with_complex_graph() -> None:
     dst, _node_map = GraphState.from_base_graph_state(src)
 
     # Verify all structure is preserved
-    assert dst.physical_nodes == set(range(5))
-    assert len(dst.physical_edges) == 4
+    assert dst.nodes == set(range(5))
+    assert len(dst.edges) == 4
     assert len(dst.input_node_indices) == 2
     assert len(dst.output_node_indices) == 2

--- a/tests/test_greedy_scheduler.py
+++ b/tests/test_greedy_scheduler.py
@@ -15,11 +15,11 @@ def test_greedy_minimize_time_simple() -> None:
     """Test greedy_minimize_time on a simple graph."""
     # Create a simple 3-node chain graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -47,9 +47,9 @@ def test_greedy_minimize_time_simple() -> None:
 def test_greedy_input_input_entanglement_delays_input_measurement(strategy: Strategy) -> None:
     """Greedy schedulers keep input-input entanglement before input measurement."""
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    graph.add_edge(node0, node1)
     graph.register_input(node0, 0)
     graph.register_input(node1, 1)
 
@@ -73,11 +73,11 @@ def test_greedy_minimize_space_simple() -> None:
     """Test greedy_minimize_space on a simple graph."""
     # Create a simple 3-node chain graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -123,7 +123,7 @@ def _compute_max_alive_qubits(
     max_alive = len(graph.input_node_indices)  # At least inputs are alive at t = -1
     for t in range(max_t + 1):
         alive_nodes: set[int] = set()
-        for node in graph.physical_nodes:
+        for node in graph.nodes:
             # Determine preparation time
             prep_t = -1 if node in graph.input_node_indices else prepare_time.get(node)
 
@@ -145,13 +145,13 @@ def test_greedy_minimize_time_with_max_qubit_count_respects_limit() -> None:
     """Verify that greedy_minimize_time respects max_qubit_count."""
     graph = GraphState()
     # chain graph: 0-1-2-3
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
-    n3 = graph.add_physical_node()
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
-    graph.add_physical_edge(n2, n3)
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
+    n3 = graph.add_node()
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
+    graph.add_edge(n2, n3)
 
     qindex = 0
     graph.register_input(n0, qindex)
@@ -179,11 +179,11 @@ def test_greedy_minimize_time_with_too_small_max_qubit_count_raises() -> None:
     """Verify that greedy_minimize_time raises RuntimeError when max_qubit_count is too small."""
     graph = GraphState()
     # chain graph: 0-1-2 (at least 2 qubits are needed)
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
 
     qindex = 0
     graph.register_input(n0, qindex)
@@ -200,16 +200,16 @@ def test_greedy_minimize_time_with_too_small_max_qubit_count_raises() -> None:
 def test_greedy_minimize_time_does_not_fill_capacity_with_unrelated_nodes() -> None:
     """Avoid preparing zero-priority nodes that cause a false capacity deadlock."""
     graph = GraphState()
-    nodes = [graph.add_physical_node() for _ in range(5)]
+    nodes = [graph.add_node() for _ in range(5)]
 
     # Connected graph:
     # 0(input) - 1 - 4(output)
     #           |
     #           3 - 2
-    graph.add_physical_edge(nodes[0], nodes[1])
-    graph.add_physical_edge(nodes[1], nodes[3])
-    graph.add_physical_edge(nodes[1], nodes[4])
-    graph.add_physical_edge(nodes[2], nodes[3])
+    graph.add_edge(nodes[0], nodes[1])
+    graph.add_edge(nodes[1], nodes[3])
+    graph.add_edge(nodes[1], nodes[4])
+    graph.add_edge(nodes[2], nodes[3])
 
     graph.register_input(nodes[0], 0)
     graph.register_output(nodes[4], 0)
@@ -231,16 +231,16 @@ def test_greedy_minimize_time_does_not_fill_capacity_with_unrelated_nodes() -> N
 def test_greedy_minimize_time_tail_outputs_preserve_capacity_limit() -> None:
     """Tail outputs should keep their existing prep times instead of being pulled earlier by ALAP."""
     graph = GraphState()
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
-    n3 = graph.add_physical_node()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
+    n3 = graph.add_node()
 
     # Connected graph:
     # 0(input) - 1 - 2(output) - 3(output)
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
-    graph.add_physical_edge(n2, n3)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
+    graph.add_edge(n2, n3)
 
     graph.register_input(n0, 0)
     graph.register_output(n2, 0)
@@ -265,11 +265,11 @@ def test_greedy_scheduler_via_solve_schedule() -> None:
     """Test greedy scheduler through Scheduler.solve_schedule with use_greedy=True."""
     # Create a simple graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -299,11 +299,11 @@ def test_greedy_vs_cpsat_correctness() -> None:
     """Test that greedy scheduler produces valid schedules compared to CP-SAT."""
     # Create a slightly larger graph
     graph = GraphState()
-    nodes = [graph.add_physical_node() for _ in range(5)]
+    nodes = [graph.add_node() for _ in range(5)]
 
     # Create a chain
     for i in range(4):
-        graph.add_physical_edge(nodes[i], nodes[i + 1])
+        graph.add_edge(nodes[i], nodes[i + 1])
 
     qindex = 0
     graph.register_input(nodes[0], qindex)
@@ -343,7 +343,7 @@ def test_greedy_scheduler_larger_graph() -> None:
     # Build layered graph
     all_nodes: list[list[int]] = []
     for layer in range(num_layers):
-        layer_nodes = [graph.add_physical_node() for _ in range(nodes_per_layer)]
+        layer_nodes = [graph.add_node() for _ in range(nodes_per_layer)]
         all_nodes.append(layer_nodes)
 
         # Connect to previous layer (if not first layer)
@@ -351,7 +351,7 @@ def test_greedy_scheduler_larger_graph() -> None:
             for i, node in enumerate(layer_nodes):
                 # Connect to corresponding node in previous layer
                 prev_node = all_nodes[layer - 1][i]
-                graph.add_physical_edge(prev_node, node)
+                graph.add_edge(prev_node, node)
 
     # Register inputs (first layer) and outputs (last layer)
     for i, node in enumerate(all_nodes[0]):
@@ -385,13 +385,13 @@ def test_greedy_scheduler_both_strategies(strategy: Strategy) -> None:
     """Test greedy scheduler with both optimization strategies."""
     # Create a graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    node3 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
-    graph.add_physical_edge(node2, node3)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    node3 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
+    graph.add_edge(node2, node3)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node3, qindex)
@@ -412,11 +412,11 @@ def test_greedy_minimize_space_wrapper() -> None:
     """Test the greedy_minimize_space wrapper function."""
     # Create a simple graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -443,17 +443,17 @@ def test_greedy_scheduler_dag_constraints() -> None:
     """Test that greedy scheduler respects DAG constraints."""
     # Create a graph with more complex dependencies
     graph = GraphState()
-    nodes = [graph.add_physical_node() for _ in range(6)]
+    nodes = [graph.add_node() for _ in range(6)]
 
     # Create edges forming a DAG structure
     #   0 -> 2 -> 4
     #        |
     #   1 -> 3 -> 5
-    graph.add_physical_edge(nodes[0], nodes[2])
-    graph.add_physical_edge(nodes[2], nodes[4])
-    graph.add_physical_edge(nodes[1], nodes[3])
-    graph.add_physical_edge(nodes[3], nodes[5])
-    graph.add_physical_edge(nodes[2], nodes[3])
+    graph.add_edge(nodes[0], nodes[2])
+    graph.add_edge(nodes[2], nodes[4])
+    graph.add_edge(nodes[1], nodes[3])
+    graph.add_edge(nodes[3], nodes[5])
+    graph.add_edge(nodes[2], nodes[3])
 
     graph.register_input(nodes[0], 0)
     graph.register_input(nodes[1], 1)
@@ -481,11 +481,11 @@ def test_greedy_scheduler_edge_constraints() -> None:
     """Test that greedy scheduler respects edge constraints (neighbor preparation)."""
     # Create a simple graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -539,17 +539,17 @@ def test_greedy_minimize_time_3x3_grid_optimal() -> None:
     # Inputs: 0, 1, 2 (left column)
     # Outputs: 6, 7, 8 (right column)
     graph = GraphState()
-    nodes = [graph.add_physical_node() for _ in range(9)]
+    nodes = [graph.add_node() for _ in range(9)]
 
     # Horizontal edges
     for row in range(3):
         for col in range(2):
-            graph.add_physical_edge(nodes[row + col * 3], nodes[row + (col + 1) * 3])
+            graph.add_edge(nodes[row + col * 3], nodes[row + (col + 1) * 3])
 
     # Vertical edges
     for row in range(2):
         for col in range(3):
-            graph.add_physical_edge(nodes[row + col * 3], nodes[row + 1 + col * 3])
+            graph.add_edge(nodes[row + col * 3], nodes[row + 1 + col * 3])
 
     # Register inputs (left column) and outputs (right column)
     for row in range(3):
@@ -583,13 +583,13 @@ def test_greedy_minimize_time_alap_preparation() -> None:
     """Test that greedy_minimize_time uses ALAP preparation to minimize active volume."""
     graph = GraphState()
     # Create a 4-node chain: 0-1-2-3
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
-    n3 = graph.add_physical_node()
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
-    graph.add_physical_edge(n2, n3)
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
+    n3 = graph.add_node()
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
+    graph.add_edge(n2, n3)
 
     graph.register_input(n0, 0)
     graph.register_output(n3, 0)
@@ -615,13 +615,13 @@ def test_alap_reduces_active_volume() -> None:
     """Test that ALAP preparation reduces active volume compared to ASAP."""
     graph = GraphState()
     # Create a chain graph: 0-1-2-3
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
-    n3 = graph.add_physical_node()
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
-    graph.add_physical_edge(n2, n3)
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
+    n3 = graph.add_node()
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
+    graph.add_edge(n2, n3)
     graph.register_input(n0, 0)
     graph.register_output(n3, 0)
 
@@ -641,15 +641,15 @@ def test_alap_preserves_depth() -> None:
     """Test that ALAP does not increase depth."""
     # Create a 3x3 grid
     graph = GraphState()
-    nodes = [graph.add_physical_node() for _ in range(9)]
+    nodes = [graph.add_node() for _ in range(9)]
 
     # Horizontal and vertical edges
     for row in range(3):
         for col in range(2):
-            graph.add_physical_edge(nodes[row + col * 3], nodes[row + (col + 1) * 3])
+            graph.add_edge(nodes[row + col * 3], nodes[row + (col + 1) * 3])
     for row in range(2):
         for col in range(3):
-            graph.add_physical_edge(nodes[row + col * 3], nodes[row + 1 + col * 3])
+            graph.add_edge(nodes[row + col * 3], nodes[row + 1 + col * 3])
 
     for row in range(3):
         graph.register_input(nodes[row], row)
@@ -673,14 +673,14 @@ def test_greedy_minimize_space_non_input_dag_root() -> None:
     causing a KeyError when removing from the alive set.
     """
     graph = GraphState()
-    n0 = graph.add_physical_node()  # input
-    n1 = graph.add_physical_node()  # non-input, DAG root (no feedforward dependency)
-    n2 = graph.add_physical_node()  # input
-    n3 = graph.add_physical_node()  # output
+    n0 = graph.add_node()  # input
+    n1 = graph.add_node()  # non-input, DAG root (no feedforward dependency)
+    n2 = graph.add_node()  # input
+    n3 = graph.add_node()  # output
 
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
-    graph.add_physical_edge(n2, n3)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
+    graph.add_edge(n2, n3)
 
     graph.register_input(n0, 0)
     graph.register_input(n2, 1)
@@ -706,12 +706,12 @@ def test_greedy_minimize_space_non_input_dag_root() -> None:
 def test_greedy_minimize_space_prepares_remaining_tail_nodes() -> None:
     """Remaining non-input nodes should receive a tail preparation time."""
     graph = GraphState()
-    n0 = graph.add_physical_node()  # input
-    n1 = graph.add_physical_node()  # output
-    n2 = graph.add_physical_node()  # output tail
+    n0 = graph.add_node()  # input
+    n1 = graph.add_node()  # output
+    n2 = graph.add_node()  # output tail
 
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
 
     graph.register_input(n0, 0)
     graph.register_output(n1, 0)

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -36,7 +36,7 @@ def pattern_components() -> tuple[dict[int, int], dict[int, int], PauliFrame, li
         Pauli frame, and list of nodes.
     """
     graph = GraphState()
-    nodes = [graph.add_physical_node() for _ in range(3)]
+    nodes = [graph.add_node() for _ in range(3)]
 
     graph.register_input(nodes[0], 0)
     graph.register_output(nodes[2], 0)
@@ -264,8 +264,8 @@ def test_idle_times_output_nodes_included_when_prepared() -> None:
     """Test that output nodes are included in idle_times when they are prepared."""
     # Create a graph where output node is also an input node
     graph = GraphState()
-    input_node = graph.add_physical_node()
-    output_node = graph.add_physical_node()
+    input_node = graph.add_node()
+    output_node = graph.add_node()
 
     graph.register_input(input_node, 0)
     graph.register_input(output_node, 1)  # Output node is also an input

--- a/tests/test_pauli_frame.py
+++ b/tests/test_pauli_frame.py
@@ -21,16 +21,16 @@ def simple_graph_with_flows() -> tuple[GraphState, dict[int, set[int]], dict[int
         GraphState, xflow, and zflow
     """
     graph = GraphState()
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
 
     q_idx = 0
     graph.register_input(n0, q_idx)
     graph.register_output(n2, q_idx)
 
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
 
     # Z measurement on n0, X measurement on n1
     graph.assign_meas_basis(n0, PlannerMeasBasis(Plane.XZ, 0.0))
@@ -60,13 +60,13 @@ def simple_pauli_frame(
     """
     graph, xflow, zflow = simple_graph_with_flows
     # Provide parity_check_group to enable _pauli_axis_cache initialization
-    parity_check_group = [set(graph.physical_nodes)]
+    parity_check_group = [set(graph.nodes)]
     return PauliFrame(graph, xflow, zflow, parity_check_group)
 
 
 @pytest.fixture
 def simple_nodes(simple_graph_with_flows: tuple[GraphState, dict[int, set[int]], dict[int, set[int]]]) -> list[int]:
-    """Get list of physical nodes from simple graph.
+    """Get list of nodes from simple graph.
 
     Parameters
     ----------
@@ -76,10 +76,10 @@ def simple_nodes(simple_graph_with_flows: tuple[GraphState, dict[int, set[int]],
     Returns
     -------
     list[int]
-        List of physical node IDs
+        List of node IDs
     """
     graph, _, _ = simple_graph_with_flows
-    return list(graph.physical_nodes)
+    return list(graph.nodes)
 
 
 @pytest.fixture
@@ -92,15 +92,15 @@ def x_axis_pauli_frame() -> PauliFrame:
         PauliFrame with X axis measurements
     """
     graph = GraphState()
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
 
     graph.register_input(n0, 0)
     graph.register_output(n2, 0)
 
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
 
     # X measurement (XY plane, angle 0)
     graph.assign_meas_basis(n0, PlannerMeasBasis(Plane.XY, 0.0))
@@ -110,7 +110,7 @@ def x_axis_pauli_frame() -> PauliFrame:
     zflow: dict[int, set[int]] = {}
 
     # Provide parity_check_group to enable _pauli_axis_cache initialization
-    parity_check_group = [set(graph.physical_nodes)]
+    parity_check_group = [set(graph.nodes)]
     return PauliFrame(graph, xflow, zflow, parity_check_group)
 
 
@@ -124,15 +124,15 @@ def y_axis_pauli_frame() -> PauliFrame:
         PauliFrame with Y axis measurements
     """
     graph = GraphState()
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
 
     graph.register_input(n0, 0)
     graph.register_output(n2, 0)
 
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
 
     # Y measurement (XY plane, angle pi/2)
     graph.assign_meas_basis(n0, PlannerMeasBasis(Plane.XY, math.pi / 2))
@@ -142,7 +142,7 @@ def y_axis_pauli_frame() -> PauliFrame:
     zflow = {n0: {n0}}
 
     # Provide parity_check_group to enable _pauli_axis_cache initialization
-    parity_check_group = [set(graph.physical_nodes)]
+    parity_check_group = [set(graph.nodes)]
     return PauliFrame(graph, xflow, zflow, parity_check_group)
 
 
@@ -156,15 +156,15 @@ def z_axis_pauli_frame() -> PauliFrame:
         PauliFrame with Z axis measurements
     """
     graph = GraphState()
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
 
     graph.register_input(n0, 0)
     graph.register_output(n2, 0)
 
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
 
     # Z measurement (XZ plane, angle 0)
     graph.assign_meas_basis(n0, PlannerMeasBasis(Plane.XZ, 0.0))
@@ -174,7 +174,7 @@ def z_axis_pauli_frame() -> PauliFrame:
     zflow: dict[int, set[int]] = {}
 
     # Provide parity_check_group to enable _pauli_axis_cache initialization
-    parity_check_group = [set(graph.physical_nodes)]
+    parity_check_group = [set(graph.nodes)]
     return PauliFrame(graph, xflow, zflow, parity_check_group)
 
 
@@ -307,7 +307,7 @@ def test_collect_dependent_chain_x_axis(x_axis_pauli_frame: PauliFrame) -> None:
     """Test dependent chain collection for X axis measurement."""
     pframe = x_axis_pauli_frame
     # Node 1 is the second node in the graph
-    nodes = list(pframe.graphstate.physical_nodes)
+    nodes = list(pframe.graphstate.nodes)
     n1 = nodes[1]
 
     # For X axis, parents come from inv_zflow
@@ -320,7 +320,7 @@ def test_collect_dependent_chain_y_axis(y_axis_pauli_frame: PauliFrame) -> None:
     """Test dependent chain collection for Y axis measurement."""
     pframe = y_axis_pauli_frame
     # Node 1 is the second node in the graph
-    nodes = list(pframe.graphstate.physical_nodes)
+    nodes = list(pframe.graphstate.nodes)
     n1 = nodes[1]
 
     # For Y axis, parents come from symmetric difference of inv_xflow and inv_zflow
@@ -333,7 +333,7 @@ def test_collect_dependent_chain_z_axis(z_axis_pauli_frame: PauliFrame) -> None:
     """Test dependent chain collection for Z axis measurement."""
     pframe = z_axis_pauli_frame
     # Node 1 is the second node in the graph
-    nodes = list(pframe.graphstate.physical_nodes)
+    nodes = list(pframe.graphstate.nodes)
     n1 = nodes[1]
 
     # For Z axis, parents come from inv_xflow
@@ -345,15 +345,15 @@ def test_collect_dependent_chain_z_axis(z_axis_pauli_frame: PauliFrame) -> None:
 def test_detector_groups() -> None:
     """Test detector groups generation with parity check groups."""
     graph = GraphState()
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
 
     graph.register_input(n0, 0)
     graph.register_output(n2, 0)
 
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
 
     graph.assign_meas_basis(n0, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(n1, PlannerMeasBasis(Plane.XY, 0.0))
@@ -379,15 +379,15 @@ def test_detector_groups() -> None:
 def test_logical_observables_group() -> None:
     """Test logical observables group generation."""
     graph = GraphState()
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
 
     graph.register_input(n0, 0)
     graph.register_output(n2, 0)
 
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
 
     graph.assign_meas_basis(n0, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(n1, PlannerMeasBasis(Plane.XY, 0.0))
@@ -397,7 +397,7 @@ def test_logical_observables_group() -> None:
     zflow: dict[int, set[int]] = {n0: {n0, n2}}
 
     # Provide parity_check_group to enable _pauli_axis_cache initialization
-    parity_check_group = [set(graph.physical_nodes)]
+    parity_check_group = [set(graph.nodes)]
     pframe = PauliFrame(graph, xflow, zflow, parity_check_group)
 
     # Get logical observables group
@@ -410,17 +410,17 @@ def test_logical_observables_group() -> None:
 def test_collect_dependent_chain_cache_hit() -> None:
     """Test that cache is correctly used when same node is queried multiple times."""
     graph = GraphState()
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
-    n3 = graph.add_physical_node()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
+    n3 = graph.add_node()
 
     graph.register_input(n0, 0)
     graph.register_output(n3, 0)
 
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n1, n2)
-    graph.add_physical_edge(n2, n3)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
+    graph.add_edge(n2, n3)
 
     # Mix of X and Z measurements
     graph.assign_meas_basis(n0, PlannerMeasBasis(Plane.XZ, 0.0))  # Z
@@ -431,7 +431,7 @@ def test_collect_dependent_chain_cache_hit() -> None:
     zflow = {n0: {n0}}
 
     # Provide parity_check_group to enable _pauli_axis_cache initialization
-    parity_check_group = [set(graph.physical_nodes)]
+    parity_check_group = [set(graph.nodes)]
     pframe = PauliFrame(graph, xflow, zflow, parity_check_group)
 
     # First call to n2
@@ -464,21 +464,21 @@ def test_collect_dependent_chain_diamond_cancellation() -> None:
     Node n0 should be canceled out because it's reached via two paths.
     """
     graph = GraphState()
-    n0 = graph.add_physical_node()
-    n1 = graph.add_physical_node()
-    n2 = graph.add_physical_node()
-    n3 = graph.add_physical_node()
-    n4 = graph.add_physical_node()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
+    n3 = graph.add_node()
+    n4 = graph.add_node()
 
     graph.register_input(n0, 0)
     graph.register_output(n4, 0)
 
     # Diamond edges + edge to output
-    graph.add_physical_edge(n0, n1)
-    graph.add_physical_edge(n0, n2)
-    graph.add_physical_edge(n1, n3)
-    graph.add_physical_edge(n2, n3)
-    graph.add_physical_edge(n3, n4)
+    graph.add_edge(n0, n1)
+    graph.add_edge(n0, n2)
+    graph.add_edge(n1, n3)
+    graph.add_edge(n2, n3)
+    graph.add_edge(n3, n4)
 
     # All Z measurements (XZ plane, angle 0) so parents come from inv_xflow
     graph.assign_meas_basis(n0, PlannerMeasBasis(Plane.XZ, 0.0))
@@ -491,7 +491,7 @@ def test_collect_dependent_chain_diamond_cancellation() -> None:
     zflow: dict[int, set[int]] = {}
 
     # Provide parity_check_group to enable _pauli_axis_cache initialization
-    parity_check_group = [set(graph.physical_nodes)]
+    parity_check_group = [set(graph.nodes)]
     pframe = PauliFrame(graph, xflow, zflow, parity_check_group)
 
     # Verify the chain for n3

--- a/tests/test_ptn_format.py
+++ b/tests/test_ptn_format.py
@@ -36,15 +36,15 @@ def create_simple_pattern() -> Pattern:
         A compiled MBQC pattern for testing.
     """
     graph = GraphState()
-    in_node = graph.add_physical_node(coordinate=(0.0, 0.0))
-    mid_node = graph.add_physical_node(coordinate=(1.0, 0.0))
-    out_node = graph.add_physical_node(coordinate=(2.0, 0.0))
+    in_node = graph.add_node(coordinate=(0.0, 0.0))
+    mid_node = graph.add_node(coordinate=(1.0, 0.0))
+    out_node = graph.add_node(coordinate=(2.0, 0.0))
 
     graph.register_input(in_node, 0)
     graph.register_output(out_node, 0)
 
-    graph.add_physical_edge(in_node, mid_node)
-    graph.add_physical_edge(mid_node, out_node)
+    graph.add_edge(in_node, mid_node)
+    graph.add_edge(mid_node, out_node)
 
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(mid_node, PlannerMeasBasis(Plane.XY, math.pi / 2))
@@ -56,12 +56,12 @@ def create_simple_pattern() -> Pattern:
 def create_measured_output_pattern_with_observable() -> Pattern:
     """Create a stim-compatible pattern with a logical observable."""
     graph = GraphState()
-    in_node = graph.add_physical_node(coordinate=(10.0, 0.0))
-    out_node = graph.add_physical_node(coordinate=(20.0, 0.0))
+    in_node = graph.add_node(coordinate=(10.0, 0.0))
+    out_node = graph.add_node(coordinate=(20.0, 0.0))
 
     graph.register_input(in_node, 0)
     graph.register_output(out_node, 0)
-    graph.add_physical_edge(in_node, out_node)
+    graph.add_edge(in_node, out_node)
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(out_node, PlannerMeasBasis(Plane.XY, 0.0))
 
@@ -71,12 +71,12 @@ def create_measured_output_pattern_with_observable() -> Pattern:
 def create_measured_output_pattern_with_detector() -> Pattern:
     """Create a stim-compatible pattern with a detector."""
     graph = GraphState()
-    in_node = graph.add_physical_node(coordinate=(30.0, 0.0))
-    out_node = graph.add_physical_node(coordinate=(40.0, 0.0))
+    in_node = graph.add_node(coordinate=(30.0, 0.0))
+    out_node = graph.add_node(coordinate=(40.0, 0.0))
 
     graph.register_input(in_node, 0)
     graph.register_output(out_node, 0)
-    graph.add_physical_edge(in_node, out_node)
+    graph.add_edge(in_node, out_node)
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(out_node, PlannerMeasBasis(Plane.XY, 0.0))
 
@@ -160,7 +160,7 @@ def test_dumps_pauli_measurements() -> None:
 def test_dumps_formats_near_known_angle() -> None:
     """Angles near known constants should serialize canonically."""
     graph = GraphState()
-    node = graph.add_physical_node()
+    node = graph.add_node()
     pattern = Pattern(
         input_node_indices={},
         output_node_indices={},
@@ -174,8 +174,8 @@ def test_dumps_formats_near_known_angle() -> None:
 def test_dumps_preserves_xz_plane_x_pauli_sign() -> None:
     """Plane.XZ X measurements should serialize with the correct Pauli sign."""
     graph = GraphState()
-    plus_node = graph.add_physical_node()
-    minus_node = graph.add_physical_node()
+    plus_node = graph.add_node()
+    minus_node = graph.add_node()
     pattern = Pattern(
         input_node_indices={},
         output_node_indices={},
@@ -205,7 +205,7 @@ def test_dumps_preserves_xz_plane_x_pauli_sign() -> None:
 def test_dumps_preserves_consecutive_trailing_ticks() -> None:
     """Empty final timeslices should preserve consecutive trailing TICK commands."""
     graph = GraphState()
-    node = graph.add_physical_node()
+    node = graph.add_node()
     pattern = Pattern(
         input_node_indices={},
         output_node_indices={},
@@ -502,18 +502,18 @@ def test_dump_and_load_file(tmp_path: Path) -> None:
 def test_multiple_input_output_qubits() -> None:
     """Test pattern with multiple input/output qubits."""
     graph = GraphState()
-    in0 = graph.add_physical_node()
-    in1 = graph.add_physical_node()
-    out0 = graph.add_physical_node()
-    out1 = graph.add_physical_node()
+    in0 = graph.add_node()
+    in1 = graph.add_node()
+    out0 = graph.add_node()
+    out1 = graph.add_node()
 
     graph.register_input(in0, 0)
     graph.register_input(in1, 1)
     graph.register_output(out0, 0)
     graph.register_output(out1, 1)
 
-    graph.add_physical_edge(in0, out0)
-    graph.add_physical_edge(in1, out1)
+    graph.add_edge(in0, out0)
+    graph.add_edge(in1, out1)
 
     graph.assign_meas_basis(in0, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(in1, PlannerMeasBasis(Plane.XY, 0.0))
@@ -659,8 +659,16 @@ Z 30
 
     assert result.input_node_indices == {10: 0}
     assert result.output_node_indices == {30: 0}
-    assert result.pauli_frame.graphstate.physical_nodes == {10, 20, 30}
-    assert result.pauli_frame.graphstate.physical_edges == {(10, 20), (20, 30)}
+    assert result.pauli_frame.graphstate.nodes == {10, 20, 30}
+    assert result.pauli_frame.graphstate.edges == {(10, 20), (20, 30)}
+    assert result.pauli_frame.graphstate.has_node(20)
+    assert result.pauli_frame.graphstate.has_edge(30, 20)
+    assert result.pauli_frame.graphstate.number_of_nodes() == 3
+    assert result.pauli_frame.graphstate.number_of_edges() == 2
+    with pytest.raises(NotImplementedError, match="read-only"):
+        result.pauli_frame.graphstate.add_node()
+    with pytest.raises(NotImplementedError, match="read-only"):
+        result.pauli_frame.graphstate.add_edge(10, 30)
     assert any(isinstance(cmd, N) and cmd.node == 20 for cmd in result.commands)
     assert any(isinstance(cmd, X) and cmd.node == 30 for cmd in result.commands)
 

--- a/tests/test_scheduler_integration.py
+++ b/tests/test_scheduler_integration.py
@@ -15,11 +15,11 @@ def test_simple_graph_scheduling() -> None:
     """Test scheduling a simple graph with solve_scheduler."""
     # Create a simple 3-node graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -45,13 +45,13 @@ def test_manual_vs_solve_scheduler_scheduling() -> None:
     """Test that manual and solve_scheduler scheduling both work."""
     # Create a graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    node3 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
-    graph.add_physical_edge(node2, node3)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    node3 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
+    graph.add_edge(node2, node3)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node3, qindex)
@@ -78,9 +78,9 @@ def test_manual_vs_solve_scheduler_scheduling() -> None:
 def test_solve_scheduler_failure_handling() -> None:
     """Test handling of solve_scheduler failures."""
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    graph.add_edge(node0, node1)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node1, qindex)
@@ -101,11 +101,11 @@ def test_schedule_config_options() -> None:
     """Test different ScheduleConfig options."""
     # Create a simple graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -138,11 +138,11 @@ def test_schedule_config_options() -> None:
 def test_minimize_space_cpsat_prepares_node_before_measuring_it() -> None:
     """Test CP-SAT MINIMIZE_SPACE enforces self preparation before measurement."""
     graph = GraphState()
-    input_node = graph.add_physical_node()
-    measured_node = graph.add_physical_node()
+    input_node = graph.add_node()
+    measured_node = graph.add_node()
     qindex = 0
 
-    graph.add_physical_edge(input_node, measured_node)
+    graph.add_edge(input_node, measured_node)
     graph.register_input(input_node, qindex)
     graph.register_output(input_node, qindex)
     graph.assign_meas_basis(measured_node, PlannerMeasBasis(Plane.YZ, 0.2))
@@ -168,11 +168,11 @@ def test_space_constrained_scheduling() -> None:
     """Test space-constrained time optimization."""
     # Create a larger graph to test constraints
     graph = GraphState()
-    nodes = [graph.add_physical_node() for _ in range(5)]
+    nodes = [graph.add_node() for _ in range(5)]
 
     # Create a chain of nodes
     for i in range(4):
-        graph.add_physical_edge(nodes[i], nodes[i + 1])
+        graph.add_edge(nodes[i], nodes[i + 1])
 
     qindex = 0
     graph.register_input(nodes[0], qindex)
@@ -197,11 +197,11 @@ def test_schedule_compression() -> None:
     """Test that schedule compression reduces unnecessary time gaps."""
     # Create a graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -242,11 +242,11 @@ def test_solve_scheduler_with_automatic_compression() -> None:
     """Test that solve_scheduler results are automatically compressed."""
     # Create a simple graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -277,11 +277,11 @@ def test_validate_schedule_valid() -> None:
     """Test that validate_schedule correctly identifies valid schedules."""
     # Create a simple graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -306,11 +306,11 @@ def test_validate_schedule_invalid_node_sets() -> None:
     """Test that validate_schedule rejects schedules with wrong node sets."""
     # Create a graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -336,11 +336,11 @@ def test_validate_schedule_missing_times() -> None:
     """Test that validate_schedule rejects schedules with missing times."""
     # Create a graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -366,13 +366,13 @@ def test_validate_schedule_dag_violations() -> None:
     """Test that validate_schedule rejects schedules violating DAG constraints."""
     # Create a graph with flow dependencies
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    node3 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
-    graph.add_physical_edge(node2, node3)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    node3 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
+    graph.add_edge(node2, node3)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node3, qindex)
@@ -398,11 +398,11 @@ def test_validate_schedule_dag_violations() -> None:
 def test_qompile_validates_provided_scheduler() -> None:
     """Qompile should reject invalid schedules before pattern generation."""
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
 
     qindex = 0
     graph.register_input(node0, qindex)
@@ -425,11 +425,11 @@ def test_validate_schedule_same_time_prep_meas() -> None:
     """Test that validate_schedule rejects schedules with nodes prepared and measured at same time."""
     # Create a graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -448,11 +448,11 @@ def test_entangle_time_scheduling() -> None:
     """Test that entanglement times can be scheduled."""
     # Create a simple graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -481,11 +481,11 @@ def test_timeline_includes_entanglement() -> None:
     """Timeline should expose preparation, entanglement, and measurement sets."""
     # Create a simple graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -521,9 +521,9 @@ def test_timeline_includes_entanglement() -> None:
 def test_input_input_entanglement_is_scheduled_in_first_slice() -> None:
     """Input-input entanglement should be kept in an executable non-negative slice."""
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    graph.add_edge(node0, node1)
     graph.register_input(node0, 0)
     graph.register_input(node1, 1)
     graph.register_output(node0, 0)
@@ -542,9 +542,9 @@ def test_input_input_entanglement_is_scheduled_in_first_slice() -> None:
 def test_cpsat_input_input_entanglement_delays_input_measurement(strategy: Strategy) -> None:
     """CP-SAT schedules input-input entanglement before measuring input endpoints."""
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    graph.add_edge(node0, node1)
     graph.register_input(node0, 0)
     graph.register_input(node1, 1)
     graph.assign_meas_basis(node0, PlannerMeasBasis(Plane.XY, 0.0))
@@ -568,9 +568,9 @@ def test_cpsat_input_input_entanglement_delays_input_measurement(strategy: Strat
 def test_cpsat_minimize_time_all_input_output_edge_is_scheduled() -> None:
     """All-input-output graphs still schedule input-input entanglement."""
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    graph.add_edge(node0, node1)
     graph.register_input(node0, 0)
     graph.register_input(node1, 1)
     graph.register_output(node0, 0)
@@ -592,9 +592,9 @@ def test_cpsat_minimize_time_all_input_output_edge_is_scheduled() -> None:
 def test_validate_schedule_rejects_negative_executable_time() -> None:
     """Executable schedule times must be non-negative."""
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    graph.add_edge(node0, node1)
     graph.register_input(node0, 0)
     graph.register_output(node1, 0)
 
@@ -610,11 +610,11 @@ def test_qompile_with_tick_commands() -> None:
     """Test that qompile generates TICK commands with scheduler."""
     # Create a simple graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -643,11 +643,11 @@ def test_validate_entangle_time_constraints() -> None:
     """Test validation of entanglement time constraints."""
     # Create a simple graph
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -693,11 +693,11 @@ def test_simulator_with_tick_commands() -> None:
     """Test that PatternSimulator handles TICK commands correctly."""
     # Create a simple graph and compile with TICK commands
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -729,11 +729,11 @@ def test_simulator_with_tick_commands() -> None:
 def test_validate_entangle_at_measurement_time_invalid() -> None:
     """Test that entanglement at same time as measurement is invalid."""
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
 
     qindex = 0
     graph.register_input(node0, qindex)
@@ -759,11 +759,11 @@ def test_validate_entangle_at_measurement_time_invalid() -> None:
 def test_validate_entangle_before_measurement_valid() -> None:
     """Test that entanglement before measurement is valid."""
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
 
     qindex = 0
     graph.register_input(node0, qindex)

--- a/tests/test_stim_compiler.py
+++ b/tests/test_stim_compiler.py
@@ -39,16 +39,16 @@ def create_simple_pattern_x_measurement() -> tuple[Pattern, int, int]:
         Pattern and expected node for X measurement
     """
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    meas_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    meas_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, meas_node)
-    graph.add_physical_edge(meas_node, out_node)
+    graph.add_edge(in_node, meas_node)
+    graph.add_edge(meas_node, out_node)
 
     # X measurement: XY plane with angle 0
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
@@ -70,16 +70,16 @@ def create_simple_pattern_y_measurement() -> tuple[Pattern, int, int]:
         Pattern and expected node for Y measurement
     """
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    meas_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    meas_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, meas_node)
-    graph.add_physical_edge(meas_node, out_node)
+    graph.add_edge(in_node, meas_node)
+    graph.add_edge(meas_node, out_node)
 
     # Y measurement: XY plane with angle π/2
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, math.pi / 2))
@@ -101,16 +101,16 @@ def create_simple_pattern_z_measurement() -> tuple[Pattern, int, int]:
         Pattern and expected node for Z measurement
     """
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    meas_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    meas_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, meas_node)
-    graph.add_physical_edge(meas_node, out_node)
+    graph.add_edge(in_node, meas_node)
+    graph.add_edge(meas_node, out_node)
 
     # Z measurement: XZ plane with angle 0
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XZ, 0.0))
@@ -241,16 +241,16 @@ def test_stim_compile_removed_legacy_noise_parameters() -> None:
 def test_stim_compile_with_detectors() -> None:
     """Test DETECTOR generation with parity check groups."""
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    meas_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    meas_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, meas_node)
-    graph.add_physical_edge(meas_node, out_node)
+    graph.add_edge(in_node, meas_node)
+    graph.add_edge(meas_node, out_node)
 
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(meas_node, PlannerMeasBasis(Plane.XY, 0.0))
@@ -335,16 +335,16 @@ def _normalize_detector(line: str) -> str:
 def test_stim_compile_with_heralded_noise_updates_detectors() -> None:
     """Heralded noise should shift rec indices used by detectors."""
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    meas_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    meas_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, meas_node)
-    graph.add_physical_edge(meas_node, out_node)
+    graph.add_edge(in_node, meas_node)
+    graph.add_edge(meas_node, out_node)
 
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(meas_node, PlannerMeasBasis(Plane.XY, 0.0))
@@ -396,16 +396,16 @@ def test_stim_compile_rejects_measurement_flip_outside_measurement(noise_model: 
 def test_stim_compile_with_logical_observables() -> None:
     """Issue #167: logical observables should compile without parity_check_group."""
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    meas_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    meas_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, meas_node)
-    graph.add_physical_edge(meas_node, out_node)
+    graph.add_edge(in_node, meas_node)
+    graph.add_edge(meas_node, out_node)
 
     # X measurement: XY plane with angle 0
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
@@ -426,16 +426,16 @@ def test_stim_compile_with_logical_observables() -> None:
 def test_stim_compile_uses_logical_observables_from_qompile() -> None:
     """Stored logical observables should be emitted when stim_compile omits them."""
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    meas_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    meas_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, meas_node)
-    graph.add_physical_edge(meas_node, out_node)
+    graph.add_edge(in_node, meas_node)
+    graph.add_edge(meas_node, out_node)
 
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(meas_node, PlannerMeasBasis(Plane.XY, 0.0))
@@ -451,16 +451,16 @@ def test_stim_compile_uses_logical_observables_from_qompile() -> None:
 def test_stim_compile_unsupported_basis() -> None:
     """Test that unsupported measurement basis raises ValueError."""
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    meas_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    meas_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, meas_node)
-    graph.add_physical_edge(meas_node, out_node)
+    graph.add_edge(in_node, meas_node)
+    graph.add_edge(meas_node, out_node)
 
     # Non-Pauli measurement: XY plane with arbitrary angle
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.1))
@@ -478,14 +478,14 @@ def test_stim_compile_unsupported_basis() -> None:
 def test_stim_compile_unsupported_output_corrections() -> None:
     """Test that X/Z correction commands in a pattern raise NotImplementedError."""
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, out_node)
+    graph.add_edge(in_node, out_node)
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
 
     xflow = {in_node: {out_node}}
@@ -498,14 +498,14 @@ def test_stim_compile_unsupported_output_corrections() -> None:
 def test_stim_compile_empty_pattern() -> None:
     """Test compilation of minimal pattern."""
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, out_node)
+    graph.add_edge(in_node, out_node)
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(out_node, PlannerMeasBasis(Plane.XY, 0.0))
 
@@ -522,16 +522,16 @@ def test_stim_compile_empty_pattern() -> None:
 def test_stim_compile_axis_meas_basis() -> None:
     """Test compilation with AxisMeasBasis."""
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    meas_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    meas_node = graph.add_node()
+    out_node = graph.add_node()
 
     q_idx = 0
     graph.register_input(in_node, q_idx)
     graph.register_output(out_node, q_idx)
 
-    graph.add_physical_edge(in_node, meas_node)
-    graph.add_physical_edge(meas_node, out_node)
+    graph.add_edge(in_node, meas_node)
+    graph.add_edge(meas_node, out_node)
 
     # Use AxisMeasBasis instead of PlannerMeasBasis
     graph.assign_meas_basis(in_node, AxisMeasBasis(Axis.X, Sign.PLUS))
@@ -552,11 +552,11 @@ def test_stim_compile_with_tick_commands() -> None:
     """Test that TICK commands are properly compiled to Stim format."""
     # Create a simple graph and compile with TICK commands
     graph = GraphState()
-    node0 = graph.add_physical_node()
-    node1 = graph.add_physical_node()
-    node2 = graph.add_physical_node()
-    graph.add_physical_edge(node0, node1)
-    graph.add_physical_edge(node1, node2)
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
     qindex = 0
     graph.register_input(node0, qindex)
     graph.register_output(node2, qindex)
@@ -641,15 +641,15 @@ def _cz_slices_from_stim(stim_str: str) -> dict[tuple[int, int], int]:
 def test_stim_compile_respects_manual_entangle_time() -> None:
     """Manual entanglement times should determine the CZ slice in both Pattern and Stim output."""
     graph = GraphState()
-    in_node = graph.add_physical_node()
-    mid_node = graph.add_physical_node()
-    out_node = graph.add_physical_node()
+    in_node = graph.add_node()
+    mid_node = graph.add_node()
+    out_node = graph.add_node()
 
     graph.register_input(in_node, 0)
     graph.register_output(out_node, 0)
 
-    graph.add_physical_edge(in_node, mid_node)
-    graph.add_physical_edge(mid_node, out_node)
+    graph.add_edge(in_node, mid_node)
+    graph.add_edge(mid_node, out_node)
 
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(mid_node, PlannerMeasBasis(Plane.XY, 0.0))
@@ -686,15 +686,15 @@ def test_stim_compile_respects_manual_entangle_time() -> None:
 def test_stim_compile_with_coordinates() -> None:
     """Test that QUBIT_COORDS instructions are emitted for nodes with coordinates."""
     graph = GraphState()
-    in_node = graph.add_physical_node(coordinate=(0.0, 0.0))
-    mid_node = graph.add_physical_node(coordinate=(1.0, 0.0))
-    out_node = graph.add_physical_node(coordinate=(2.0, 0.0))
+    in_node = graph.add_node(coordinate=(0.0, 0.0))
+    mid_node = graph.add_node(coordinate=(1.0, 0.0))
+    out_node = graph.add_node(coordinate=(2.0, 0.0))
 
     graph.register_input(in_node, 0)
     graph.register_output(out_node, 0)
 
-    graph.add_physical_edge(in_node, mid_node)
-    graph.add_physical_edge(mid_node, out_node)
+    graph.add_edge(in_node, mid_node)
+    graph.add_edge(mid_node, out_node)
 
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(mid_node, PlannerMeasBasis(Plane.XY, 0.0))
@@ -712,13 +712,13 @@ def test_stim_compile_with_coordinates() -> None:
 def test_stim_compile_with_3d_coordinates() -> None:
     """Test that 3D coordinates are correctly emitted."""
     graph = GraphState()
-    in_node = graph.add_physical_node(coordinate=(0.0, 0.0, 0.0))
-    out_node = graph.add_physical_node(coordinate=(1.0, 1.0, 1.0))
+    in_node = graph.add_node(coordinate=(0.0, 0.0, 0.0))
+    out_node = graph.add_node(coordinate=(1.0, 1.0, 1.0))
 
     graph.register_input(in_node, 0)
     graph.register_output(out_node, 0)
 
-    graph.add_physical_edge(in_node, out_node)
+    graph.add_edge(in_node, out_node)
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(out_node, PlannerMeasBasis(Plane.XY, 0.0))
 
@@ -732,13 +732,13 @@ def test_stim_compile_with_3d_coordinates() -> None:
 def test_stim_compile_without_coordinates() -> None:
     """Test that no QUBIT_COORDS are emitted when emit_qubit_coords is False."""
     graph = GraphState()
-    in_node = graph.add_physical_node(coordinate=(0.0, 0.0))
-    out_node = graph.add_physical_node(coordinate=(1.0, 0.0))
+    in_node = graph.add_node(coordinate=(0.0, 0.0))
+    out_node = graph.add_node(coordinate=(1.0, 0.0))
 
     graph.register_input(in_node, 0)
     graph.register_output(out_node, 0)
 
-    graph.add_physical_edge(in_node, out_node)
+    graph.add_edge(in_node, out_node)
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(out_node, PlannerMeasBasis(Plane.XY, 0.0))
 
@@ -751,15 +751,15 @@ def test_stim_compile_without_coordinates() -> None:
 def test_pattern_coordinates_property() -> None:
     """Test that Pattern.coordinates aggregates coordinates from N commands and input nodes."""
     graph = GraphState()
-    in_node = graph.add_physical_node(coordinate=(0.0, 0.0))
-    mid_node = graph.add_physical_node(coordinate=(1.0, 0.0))
-    out_node = graph.add_physical_node(coordinate=(2.0, 0.0))
+    in_node = graph.add_node(coordinate=(0.0, 0.0))
+    mid_node = graph.add_node(coordinate=(1.0, 0.0))
+    out_node = graph.add_node(coordinate=(2.0, 0.0))
 
     graph.register_input(in_node, 0)
     graph.register_output(out_node, 0)
 
-    graph.add_physical_edge(in_node, mid_node)
-    graph.add_physical_edge(mid_node, out_node)
+    graph.add_edge(in_node, mid_node)
+    graph.add_edge(mid_node, out_node)
 
     graph.assign_meas_basis(in_node, PlannerMeasBasis(Plane.XY, 0.0))
     graph.assign_meas_basis(mid_node, PlannerMeasBasis(Plane.XY, 0.0))

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -24,12 +24,12 @@ def graph_with_coordinates() -> GraphState:
         A graph with nodes at coordinates (0,0), (1,0), (2,0).
     """
     graph = GraphState()
-    node1 = graph.add_physical_node(coordinate=(0.0, 0.0))
-    node2 = graph.add_physical_node(coordinate=(1.0, 0.0))
-    node3 = graph.add_physical_node(coordinate=(2.0, 0.0))
+    node1 = graph.add_node(coordinate=(0.0, 0.0))
+    node2 = graph.add_node(coordinate=(1.0, 0.0))
+    node3 = graph.add_node(coordinate=(2.0, 0.0))
 
-    graph.add_physical_edge(node1, node2)
-    graph.add_physical_edge(node2, node3)
+    graph.add_edge(node1, node2)
+    graph.add_edge(node2, node3)
 
     graph.register_input(node1, 0)
     graph.register_output(node3, 0)
@@ -58,12 +58,12 @@ def test_visualize_with_partial_coordinates() -> None:
     """Test that visualize handles graphs with partial coordinates."""
     graph = GraphState()
     # Only some nodes have coordinates
-    node1 = graph.add_physical_node(coordinate=(0.0, 0.0))
-    node2 = graph.add_physical_node()  # No coordinate
-    node3 = graph.add_physical_node(coordinate=(2.0, 0.0))
+    node1 = graph.add_node(coordinate=(0.0, 0.0))
+    node2 = graph.add_node()  # No coordinate
+    node3 = graph.add_node(coordinate=(2.0, 0.0))
 
-    graph.add_physical_edge(node1, node2)
-    graph.add_physical_edge(node2, node3)
+    graph.add_edge(node1, node2)
+    graph.add_edge(node2, node3)
 
     graph.register_input(node1, 0)
     graph.register_output(node3, 0)
@@ -79,10 +79,10 @@ def test_visualize_with_partial_coordinates() -> None:
 def test_visualize_with_3d_coordinates() -> None:
     """Test that visualize projects 3D coordinates to 2D."""
     graph = GraphState()
-    node1 = graph.add_physical_node(coordinate=(0.0, 0.0, 0.0))
-    node2 = graph.add_physical_node(coordinate=(1.0, 1.0, 1.0))
+    node1 = graph.add_node(coordinate=(0.0, 0.0, 0.0))
+    node2 = graph.add_node(coordinate=(1.0, 1.0, 1.0))
 
-    graph.add_physical_edge(node1, node2)
+    graph.add_edge(node1, node2)
 
     graph.register_input(node1, 0)
     graph.register_output(node2, 0)
@@ -97,10 +97,10 @@ def test_visualize_with_3d_coordinates() -> None:
 def test_visualize_with_1d_coordinates() -> None:
     """Test that visualize handles 1D coordinates by using y=0."""
     graph = GraphState()
-    node1 = graph.add_physical_node(coordinate=(0.0,))
-    node2 = graph.add_physical_node(coordinate=(1.0,))
+    node1 = graph.add_node(coordinate=(0.0,))
+    node2 = graph.add_node(coordinate=(1.0,))
 
-    graph.add_physical_edge(node1, node2)
+    graph.add_edge(node1, node2)
 
     graph.register_input(node1, 0)
     graph.register_output(node2, 0)
@@ -115,10 +115,10 @@ def test_visualize_with_1d_coordinates() -> None:
 def test_visualize_empty_coordinates() -> None:
     """Test that visualize works with empty graph coordinates."""
     graph = GraphState()
-    node1 = graph.add_physical_node()  # No coordinate
-    node2 = graph.add_physical_node()  # No coordinate
+    node1 = graph.add_node()  # No coordinate
+    node2 = graph.add_node()  # No coordinate
 
-    graph.add_physical_edge(node1, node2)
+    graph.add_edge(node1, node2)
 
     graph.register_input(node1, 0)
     graph.register_output(node2, 0)

--- a/tests/test_zx_util.py
+++ b/tests/test_zx_util.py
@@ -330,7 +330,7 @@ def test_from_pyzx_builds_graphstate() -> None:
 
     assert graph.input_node_indices == {input_node: 0}
     assert graph.output_node_indices == {synthetic_output: 0}
-    assert graph.physical_edges == {
+    assert graph.edges == {
         tuple(sorted((input_node, first_node))),
         tuple(sorted((first_node, second_node))),
         tuple(sorted((second_node, output_node))),
@@ -371,4 +371,4 @@ def test_from_pyzx_recognizes_phase_gadget_as_yz_measurement() -> None:
     assert (3.0, 1.0) not in coord_to_node
     assert graph.meas_bases[hub_node].plane == Plane.YZ
     assert math.isclose(graph.meas_bases[hub_node].angle, math.pi / 4)
-    assert len(graph.physical_nodes) == 6
+    assert len(graph.nodes) == 6


### PR DESCRIPTION
## Summary
- replace GraphState physical_* graph API with standard nodes/edges and add_node/add_edge/remove_node/remove_edge methods
- remove the legacy compatibility wrappers for the v0.4.0 API shape
- update internal callers, docs, examples, and tests to use the new API
- add regression coverage for compose with non-contiguous explicit node ids and .ptn-loaded graph states

## Validation
- uv run --no-sync ruff check
- uv run --no-sync pyright
- uv run --no-sync pytest tests/test_graphstate.py tests/test_graph_compose.py tests/test_ptn_format.py
- uv run --no-sync pytest --ignore=tests/test_zx_util.py

Note: full pytest collection without the ignore still hits the existing PyZX API mismatch in tests/test_zx_util.py.