### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-19
+
 ### Added
 
 - **QEC Stim MPP Import**: Added utilities for building `StabilizerCode` inputs from unsigned Stim `MPP` layers, including sparse Stim qubit id mapping, coordinate import, multi-layer selection, detector/logical-observable import, and the optional `graphqomb[stim]` extra. Signed products using inverted Pauli targets are rejected because stabilizer signs are not retained.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graphqomb"
-version = "0.3.1"
+version = "0.4.0"
 description = "A modular Graph State qompiler for measurement-based quantum computing."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -704,7 +704,7 @@ wheels = [
 
 [[package]]
 name = "graphqomb"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
**Context (if applicable):**

Prepare the GraphQOMB v0.4.0 release after the features currently documented under `Unreleased` landed on `master`.

**Description of the change:**

- Update the project version from `0.3.1` to `0.4.0`.
- Keep the editable GraphQOMB package version in `uv.lock` aligned with the project metadata.
- Move the accumulated changelog entries into a `0.4.0` section dated 2026-07-19.

**Validation:**

- `uv lock --check`
- Package metadata reports `0.4.0`
- `uv run --extra stim pytest -q` (`667 passed`)
- `git diff --check`

**Related issue:**

None.