### PR TITLE
Fix PyPI publish action reference

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -39,7 +39,7 @@ jobs:
         run: uv run --with twine==6.2.0 twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Extract version from tag
         id: get_version


### PR DESCRIPTION
## Summary

- replace the unresolved `pypa/gh-action-pypi-publish@v1` reference with the supported `pypa/gh-action-pypi-publish@release/v1` reference

## Root cause

The release workflow failed while GitHub Actions was resolving required actions because the PyPA publisher action does not provide a `v1` ref. The supported v1 release branch is `release/v1`, so no build or publish step could start with the previous reference.

## Impact

Future tag-triggered release runs can resolve the PyPI publishing action and proceed to the build and trusted-publishing steps.

## Validation

- parsed `.github/workflows/publish-to-pypi.yml` successfully as YAML
- ran `git diff --check`
- confirmed the official `release/v1` ref exists through the GitHub API
- confirmed no `pypa/gh-action-pypi-publish@v1` reference remains