### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-20
+
 ### Added
 
 - **Stim Clifford Parser**: Added `graphqomb.stim_parser` for normalizing Stim Clifford circuits to the Clifford `J`/`CZ` basis: `H = J(0)`, `HS = J(pi/2)` (Stim `C_XNYZ`), `HZ = J(pi)` (Stim `SQRT_Y`), and `HS_DAG = J(-pi/2)` (Stim `C_XYZ`), corresponding to X+/Y+/X-/Y- measurements. The parser covers fixed one- and two-qubit Clifford gates, `SPP`/`SPP_DAG`, nested repeats, `R`/`RX`/`RY` and `M`/`MX`/`MY` boundaries, preserved record/annotation instructions, and detailed rejection of unsupported instructions. Optimization canonicalizes every single-qubit gate run to its shortest word over the four `J` gates (at most three per single-qubit Clifford), cancels redundant `CZ` pairs, and folds gates at those Pauli reset and measurement boundaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graphqomb"
-version = "0.4.0"
+version = "0.4.1"
 description = "A modular Graph State qompiler for measurement-based quantum computing."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -704,7 +704,7 @@ wheels = [
 
 [[package]]
 name = "graphqomb"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary

Prepare GraphQOMB v0.4.1 for release.

## Changes

- add the v0.4.1 changelog section for the Stim Clifford parser and importer integration
- bump the package version from 0.4.0 to 0.4.1
- update the lockfile package metadata to 0.4.1

## Impact

This patch release publishes the Stim Clifford parser introduced since v0.4.0 and the corresponding Stim circuit import normalization.

## Validation

- `uv lock --check`
- package metadata version check (`0.4.1`)
- `uv run --extra stim pytest -q` — 795 passed, 1 skipped
- `git diff --check origin/master...HEAD`
