### PR TITLE
Avoid overlapping MPP ancilla coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **QEC Graph-State Coordinates**: Move automatically positioned MPP ancillas aside when their support centroid's XY projection is already occupied by another node, while preserving the inferred temporal coordinate and explicit ancilla coordinates.
+- **QEC Graph-State Coordinates**: Move automatically positioned MPP ancillas aside when their support centroid's XY projection is already occupied by another node, using clearance scaled to the graph's coordinate span while preserving the inferred temporal coordinate and explicit ancilla coordinates.
 
 ## [0.4.1] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **QEC Graph-State Coordinates**: Move automatically positioned MPP ancillas aside when their support centroid is already occupied by another node, while preserving the inferred temporal coordinate and explicit ancilla coordinates.
+- **QEC Graph-State Coordinates**: Move automatically positioned MPP ancillas aside when their support centroid's XY projection is already occupied by another node, while preserving the inferred temporal coordinate and explicit ancilla coordinates.
 
 ## [0.4.1] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **QEC Graph-State Coordinates**: Move automatically positioned MPP ancillas aside when their support centroid is already occupied by another node, while preserving the inferred temporal coordinate and explicit ancilla coordinates.
+
 ## [0.4.1] - 2026-07-20
 
 ### Added

--- a/docs/source/qec.rst
+++ b/docs/source/qec.rst
@@ -8,9 +8,10 @@ Coordinate tuples are retained without restricting their dimensionality. The
 graph-state builder uses the first two qubit-coordinate components for the data
 plane and the first three explicitly supplied stabilizer-coordinate components
 for ancilla placement. An ancilla without an explicit coordinate is placed at
-the centroid of its connected data nodes. If that centroid is already occupied,
-the ancilla is moved in the data plane to a nearby candidate position with
-clearance from existing nodes; its temporal coordinate is left unchanged.
+the centroid of its connected data nodes. If that centroid's XY projection is
+already occupied, the ancilla is moved in the data plane to a nearby candidate
+position with clearance from existing nodes; its temporal coordinate is left
+unchanged.
 
 With ``data_as_io=True``, the stabilizer-measurement unit has a separate,
 unmeasured output layer. Type I therefore has two measured data layers followed

--- a/docs/source/qec.rst
+++ b/docs/source/qec.rst
@@ -10,8 +10,9 @@ plane and the first three explicitly supplied stabilizer-coordinate components
 for ancilla placement. An ancilla without an explicit coordinate is placed at
 the centroid of its connected data nodes. If that centroid's XY projection is
 already occupied, the ancilla is moved in the data plane to a nearby candidate
-position with clearance from existing nodes; its temporal coordinate is left
-unchanged.
+position with clearance from existing nodes. The clearance scales with the XY
+coordinate span so that it remains visible for large coordinate ranges; the
+temporal coordinate is left unchanged.
 
 With ``data_as_io=True``, the stabilizer-measurement unit has a separate,
 unmeasured output layer. Type I therefore has two measured data layers followed

--- a/docs/source/qec.rst
+++ b/docs/source/qec.rst
@@ -7,7 +7,10 @@ Type I and Type II graph-state builders used by the QEC helper workflow.
 Coordinate tuples are retained without restricting their dimensionality. The
 graph-state builder uses the first two qubit-coordinate components for the data
 plane and the first three explicitly supplied stabilizer-coordinate components
-for ancilla placement.
+for ancilla placement. An ancilla without an explicit coordinate is placed at
+the centroid of its connected data nodes. If that centroid is already occupied,
+the ancilla is moved in the data plane to a nearby candidate position with
+clearance from existing nodes; its temporal coordinate is left unchanged.
 
 With ``data_as_io=True``, the stabilizer-measurement unit has a separate,
 unmeasured output layer. Type I therefore has two measured data layers followed

--- a/graphqomb/qec/qeccode.py
+++ b/graphqomb/qec/qeccode.py
@@ -508,7 +508,7 @@ def _avoid_occupied_coordinate(
         The original coordinate when unoccupied, otherwise a nearby free one.
     """
     occupied_coordinates = tuple(graph.coordinates.values())
-    if not any(math.dist(coordinate, occupied) <= _COORDINATE_TOLERANCE for occupied in occupied_coordinates):
+    if not any(math.dist(coordinate[:2], occupied[:2]) <= _COORDINATE_TOLERANCE for occupied in occupied_coordinates):
         return coordinate
 
     x, y, z = coordinate
@@ -518,7 +518,7 @@ def _avoid_occupied_coordinate(
         for dx, dy in _ANCILLA_ESCAPE_DIRECTIONS:
             candidate = (x + dx * distance, y + dy * distance, z)
             if all(
-                math.dist(candidate, occupied) >= _ANCILLA_COLLISION_CLEARANCE - _COORDINATE_TOLERANCE
+                math.dist(candidate[:2], occupied[:2]) >= _ANCILLA_COLLISION_CLEARANCE - _COORDINATE_TOLERANCE
                 for occupied in occupied_coordinates
             ):
                 return candidate

--- a/graphqomb/qec/qeccode.py
+++ b/graphqomb/qec/qeccode.py
@@ -18,7 +18,8 @@ if TYPE_CHECKING:
 
 
 _TYPE_II_CHAIN_LENGTH = 3
-_ANCILLA_COLLISION_CLEARANCE = 0.5
+_MIN_ANCILLA_COLLISION_CLEARANCE = 0.5
+_ANCILLA_COLLISION_CLEARANCE_RATIO = 0.05
 _COORDINATE_TOLERANCE = 1e-9
 _ANCILLA_ESCAPE_DIRECTIONS = (
     (1.0, 0.0),
@@ -506,20 +507,42 @@ def _avoid_occupied_coordinate(
     -------
     `tuple`[`float`, `float`, `float`]
         The original coordinate when unoccupied, otherwise a nearby free one.
+
+    Raises
+    ------
+    ValueError
+        If no finite candidate can be found within the bounded search.
     """
-    occupied_coordinates = tuple(graph.coordinates.values())
+    if not all(math.isfinite(value) for value in coordinate[:2]):
+        return coordinate
+
+    occupied_coordinates = tuple(
+        occupied for occupied in graph.coordinates.values() if all(math.isfinite(value) for value in occupied[:2])
+    )
     if not any(math.dist(coordinate[:2], occupied[:2]) <= _COORDINATE_TOLERANCE for occupied in occupied_coordinates):
         return coordinate
 
+    x_coordinates = tuple(occupied[0] for occupied in occupied_coordinates)
+    y_coordinates = tuple(occupied[1] for occupied in occupied_coordinates)
+    scaled_coordinate_span = max(
+        max(x_coordinates) * _ANCILLA_COLLISION_CLEARANCE_RATIO
+        - min(x_coordinates) * _ANCILLA_COLLISION_CLEARANCE_RATIO,
+        max(y_coordinates) * _ANCILLA_COLLISION_CLEARANCE_RATIO
+        - min(y_coordinates) * _ANCILLA_COLLISION_CLEARANCE_RATIO,
+    )
+    clearance = max(_MIN_ANCILLA_COLLISION_CLEARANCE, scaled_coordinate_span)
+
     x, y, z = coordinate
-    radius = 1
-    while True:
-        distance = radius * _ANCILLA_COLLISION_CLEARANCE
+    max_radius = 3 * len(occupied_coordinates) + 1
+    for radius in range(1, max_radius + 1):
+        distance = radius * clearance
         for dx, dy in _ANCILLA_ESCAPE_DIRECTIONS:
             candidate = (x + dx * distance, y + dy * distance, z)
-            if all(
-                math.dist(candidate[:2], occupied[:2]) >= _ANCILLA_COLLISION_CLEARANCE - _COORDINATE_TOLERANCE
+            if all(math.isfinite(value) for value in candidate[:2]) and all(
+                math.dist(candidate[:2], occupied[:2]) >= clearance - _COORDINATE_TOLERANCE
                 for occupied in occupied_coordinates
             ):
                 return candidate
-        radius += 1
+
+    msg = "could not find a finite coordinate for the inferred ancilla"
+    raise ValueError(msg)

--- a/graphqomb/qec/qeccode.py
+++ b/graphqomb/qec/qeccode.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections import defaultdict
 from enum import Enum, auto
 from itertools import combinations
@@ -17,6 +18,18 @@ if TYPE_CHECKING:
 
 
 _TYPE_II_CHAIN_LENGTH = 3
+_ANCILLA_COLLISION_CLEARANCE = 0.5
+_COORDINATE_TOLERANCE = 1e-9
+_ANCILLA_ESCAPE_DIRECTIONS = (
+    (1.0, 0.0),
+    (-1.0, 0.0),
+    (0.0, 1.0),
+    (0.0, -1.0),
+    (1.0, 1.0),
+    (1.0, -1.0),
+    (-1.0, 1.0),
+    (-1.0, -1.0),
+)
 Coordinate = tuple[float, ...]
 
 
@@ -302,7 +315,7 @@ def _add_ancilla_nodes(
         if explicit_ancilla_coord is None:
             inferred_coord = _average_node_coordinates(graph, connected_data_nodes)
             if inferred_coord is not None:
-                graph.set_coordinate(ancilla_node, inferred_coord)
+                graph.set_coordinate(ancilla_node, _avoid_occupied_coordinate(graph, inferred_coord))
 
     for left_stabilizer, right_stabilizer in _twisted_stabilizer_pairs(supports):
         graph.add_edge(ancilla_nodes[left_stabilizer], ancilla_nodes[right_stabilizer])
@@ -477,3 +490,36 @@ def _average_node_coordinates(graph: GraphState, nodes: list[int]) -> tuple[floa
         sum(coordinates[node][1] for node in nodes) / len(nodes),
         sum(coordinates[node][2] for node in nodes) / len(nodes),
     )
+
+
+def _avoid_occupied_coordinate(
+    graph: GraphState,
+    coordinate: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    """Move an inferred ancilla coordinate aside when its centroid is occupied.
+
+    The temporal coordinate is preserved. Candidate positions expand
+    deterministically in the data plane until one has enough clearance from
+    every node whose coordinate has already been assigned.
+
+    Returns
+    -------
+    `tuple`[`float`, `float`, `float`]
+        The original coordinate when unoccupied, otherwise a nearby free one.
+    """
+    occupied_coordinates = tuple(graph.coordinates.values())
+    if not any(math.dist(coordinate, occupied) <= _COORDINATE_TOLERANCE for occupied in occupied_coordinates):
+        return coordinate
+
+    x, y, z = coordinate
+    radius = 1
+    while True:
+        distance = radius * _ANCILLA_COLLISION_CLEARANCE
+        for dx, dy in _ANCILLA_ESCAPE_DIRECTIONS:
+            candidate = (x + dx * distance, y + dy * distance, z)
+            if all(
+                math.dist(candidate, occupied) >= _ANCILLA_COLLISION_CLEARANCE - _COORDINATE_TOLERANCE
+                for occupied in occupied_coordinates
+            ):
+                return candidate
+        radius += 1

--- a/tests/test_qec.py
+++ b/tests/test_qec.py
@@ -318,6 +318,37 @@ def test_build_graph_state_moves_ancilla_off_data_qubit_at_support_centroid() ->
     assert coords[result.ancilla_nodes[0]] == (1.5, 0.0, 1.0)
 
 
+def test_build_graph_state_scales_ancilla_clearance_with_coordinate_span() -> None:
+    code = StabilizerCode(
+        _matrix([[1, 0, 1, 0, 0, 0]]),
+        qubit_coords={
+            0: (0.0, 0.0),
+            1: (1000.0, 0.0),
+            2: (2000.0, 0.0),
+        },
+    )
+
+    result = build_graph_state(code)
+
+    assert result.graph.coordinates[result.ancilla_nodes[0]] == (1100.0, 0.0, 1.0)
+
+
+def test_build_graph_state_ignores_nonfinite_coordinates_when_avoiding_overlap() -> None:
+    code = StabilizerCode(
+        _matrix([[1, 1, 0, 0, 0, 0, 0, 0]]),
+        qubit_coords={
+            0: (-1.0, 0.0),
+            1: (1.0, 0.0),
+            2: (0.0, 0.0),
+            3: (float("nan"), 5.0),
+        },
+    )
+
+    result = build_graph_state(code)
+
+    assert result.graph.coordinates[result.ancilla_nodes[0]] == (0.5, 0.0, 1.0)
+
+
 def test_build_graph_state_uses_next_escape_direction_when_first_is_occupied() -> None:
     code = StabilizerCode(
         _matrix([[1, 0, 0, 1, 0, 0, 0, 0]]),

--- a/tests/test_qec.py
+++ b/tests/test_qec.py
@@ -287,6 +287,20 @@ def test_build_graph_state_type_ii_moves_ancilla_off_overlapping_middle_node() -
     assert coords[result.ancilla_nodes[0]] == (10.5, 20.0, 5.5)
 
 
+def test_build_graph_state_type_i_moves_ancilla_off_same_xy_projection() -> None:
+    code = StabilizerCode(
+        _matrix([[1, 1]]),
+        qubit_coords={0: (10.0, 20.0)},
+    )
+
+    result = build_graph_state(code, z_base=5, y_foliation=YFoliation.TYPE_I)
+    coords = result.graph.coordinates
+
+    assert coords[result.data_nodes[0, 5]] == (10.0, 20.0, 5.0)
+    assert coords[result.data_nodes[0, 6]] == (10.0, 20.0, 6.0)
+    assert coords[result.ancilla_nodes[0]] == (10.5, 20.0, 5.5)
+
+
 def test_build_graph_state_moves_ancilla_off_data_qubit_at_support_centroid() -> None:
     code = StabilizerCode(
         _matrix([[1, 0, 1, 0, 0, 0]]),
@@ -312,6 +326,32 @@ def test_build_graph_state_uses_next_escape_direction_when_first_is_occupied() -
             1: (1.5, 0.0),
             2: (2.0, 0.0),
             3: (3.0, 0.0),
+        },
+    )
+
+    result = build_graph_state(code)
+
+    assert result.graph.coordinates[result.ancilla_nodes[0]] == (1.0, 0.0, 1.0)
+
+
+def test_build_graph_state_expands_escape_radius_when_first_ring_is_occupied() -> None:
+    escape_ring = [
+        (0.5, 0.0),
+        (-0.5, 0.0),
+        (0.0, 0.5),
+        (0.0, -0.5),
+        (0.5, 0.5),
+        (0.5, -0.5),
+        (-0.5, 0.5),
+        (-0.5, -0.5),
+    ]
+    code = StabilizerCode(
+        _matrix([[1, 1, *([0] * 9), *([0] * 11)]]),
+        qubit_coords={
+            0: (-2.0, 0.0),
+            1: (2.0, 0.0),
+            2: (0.0, 0.0),
+            **dict(enumerate(escape_ring, start=3)),
         },
     )
 

--- a/tests/test_qec.py
+++ b/tests/test_qec.py
@@ -271,7 +271,7 @@ def test_build_graph_state_type_ii_keeps_two_node_x_chain_without_y_support() ->
         _assert_axis_meas_basis(graph.meas_bases[data_node], Axis.X)
 
 
-def test_build_graph_state_type_ii_aligns_three_node_chain_output_z_with_two_node_chain() -> None:
+def test_build_graph_state_type_ii_moves_ancilla_off_overlapping_middle_node() -> None:
     code = StabilizerCode(
         _matrix([[1, 1]]),
         qubit_coords={0: (10.0, 20.0)},
@@ -284,7 +284,40 @@ def test_build_graph_state_type_ii_aligns_three_node_chain_output_z_with_two_nod
     assert coords[result.data_nodes[0, 5]] == (10.0, 20.0, 5.0)
     assert coords[result.data_nodes[0, 6]] == (10.0, 20.0, 5.5)
     assert coords[result.data_nodes[0, 7]] == (10.0, 20.0, 6.0)
-    assert coords[result.ancilla_nodes[0]] == (10.0, 20.0, 5.5)
+    assert coords[result.ancilla_nodes[0]] == (10.5, 20.0, 5.5)
+
+
+def test_build_graph_state_moves_ancilla_off_data_qubit_at_support_centroid() -> None:
+    code = StabilizerCode(
+        _matrix([[1, 0, 1, 0, 0, 0]]),
+        qubit_coords={
+            0: (0.0, 0.0),
+            1: (1.0, 0.0),
+            2: (2.0, 0.0),
+        },
+    )
+
+    result = build_graph_state(code)
+    coords = result.graph.coordinates
+
+    assert coords[result.data_nodes[1, 1]] == (1.0, 0.0, 1.0)
+    assert coords[result.ancilla_nodes[0]] == (1.5, 0.0, 1.0)
+
+
+def test_build_graph_state_uses_next_escape_direction_when_first_is_occupied() -> None:
+    code = StabilizerCode(
+        _matrix([[1, 0, 0, 1, 0, 0, 0, 0]]),
+        qubit_coords={
+            0: (0.0, 0.0),
+            1: (1.5, 0.0),
+            2: (2.0, 0.0),
+            3: (3.0, 0.0),
+        },
+    )
+
+    result = build_graph_state(code)
+
+    assert result.graph.coordinates[result.ancilla_nodes[0]] == (1.0, 0.0, 1.0)
 
 
 @pytest.mark.parametrize("y_foliation", [YFoliation.TYPE_I, YFoliation.TYPE_II])


### PR DESCRIPTION
## Summary

- detect when an automatically inferred MPP ancilla centroid is already occupied
- keep the inferred temporal coordinate and deterministically search nearby XY positions for sufficient clearance
- preserve existing behavior for unoccupied centroids and explicitly supplied ancilla coordinates
- document the placement rule and add regression coverage for blocked fallback positions

## Root cause

MPP ancillas without explicit coordinates were always assigned the component-wise centroid of their connected data nodes. The builder did not check whether another graph node already occupied that coordinate, so nodes could render on top of one another.

## Impact

Coordinate-aware MPP imports now remain visually distinguishable when a support centroid coincides with a data qubit or another previously positioned node. Graph construction and temporal placement semantics are unchanged.

## Validation

- `python -m pytest -s -q` — 797 passed, 1 skipped
- `ruff format --check graphqomb/qec/qeccode.py tests/test_qec.py`
- `ruff check graphqomb/qec/qeccode.py tests/test_qec.py`
- `mypy graphqomb/qec/qeccode.py tests/test_qec.py`
- `pyright graphqomb/qec/qeccode.py tests/test_qec.py`