### PR TITLE
Add aggregate logical observable groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pauli Frame Logical Observables**: Added `PauliFrame.logical_observable_groups()` to return all indexed logical observables after dependent-chain expansion, matching the all-groups behavior of `detector_groups()`; Stim export now uses the new aggregate API.
+
 ### Fixed
 
 - **QEC Graph-State Coordinates**: Move automatically positioned MPP ancillas aside when their support centroid's XY projection is already occupied by another node, using clearance scaled to the graph's coordinate span while preserving the inferred temporal coordinate and explicit ancilla coordinates.

--- a/graphqomb/pauli_frame.py
+++ b/graphqomb/pauli_frame.py
@@ -178,6 +178,19 @@ class PauliFrame:
 
         return groups
 
+    def logical_observable_groups(self) -> dict[int, set[int]]:
+        r"""Get all logical observable groups after dependent-chain expansion.
+
+        Returns
+        -------
+        `dict`\[`int`, `set`\[`int`\]\]
+            The expanded logical observable groups keyed by logical index.
+        """
+        return {
+            logical_idx: self.logical_observables_group(target_nodes)
+            for logical_idx, target_nodes in self.logical_observables.items()
+        }
+
     def logical_observables_group(self, target_nodes: Collection[int]) -> set[int]:
         r"""Get the logical observables group for the given target nodes.
 

--- a/graphqomb/stim_compiler.py
+++ b/graphqomb/stim_compiler.py
@@ -70,8 +70,7 @@ class _StimCompiler:
             self._stim_io.write(f"DETECTOR {' '.join(targets)}\n")
 
     def _emit_observables(self, total_measurements: int) -> None:
-        for log_idx, obs in sorted(self._pframe.logical_observables.items()):
-            group = self._pframe.logical_observables_group(obs)
+        for log_idx, group in sorted(self._pframe.logical_observable_groups().items()):
             targets = [f"rec[{self._meas_order[n] - total_measurements}]" for n in group]
             self._stim_io.write(f"OBSERVABLE_INCLUDE({log_idx}) {' '.join(targets)}\n")
 

--- a/tests/test_pauli_frame.py
+++ b/tests/test_pauli_frame.py
@@ -407,6 +407,35 @@ def test_logical_observables_group() -> None:
     assert group == {n0, n2}  # n0 is included via dependent chain
 
 
+def test_logical_observable_groups() -> None:
+    """Test closure expansion for all indexed logical observables."""
+    graph = GraphState()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    n2 = graph.add_node()
+
+    graph.register_input(n0, 0)
+    graph.register_output(n2, 0)
+
+    graph.add_edge(n0, n1)
+    graph.add_edge(n1, n2)
+
+    graph.assign_meas_basis(n0, PlannerMeasBasis(Plane.XY, 0.0))
+    graph.assign_meas_basis(n1, PlannerMeasBasis(Plane.XY, 0.0))
+    graph.assign_meas_basis(n2, PlannerMeasBasis(Plane.XY, 0.0))
+
+    xflow = {n0: {n1}, n1: {n2}}
+    zflow: dict[int, set[int]] = {n0: {n0, n2}}
+    logical_observables = {3: {n1}, 7: {n2}}
+
+    pframe = PauliFrame(graph, xflow, zflow, logical_observables=logical_observables)
+
+    assert pframe.logical_observable_groups() == {
+        3: {n1},
+        7: {n0, n2},
+    }
+
+
 def test_collect_dependent_chain_cache_hit() -> None:
     """Test that cache is correctly used when same node is queried multiple times."""
     graph = GraphState()


### PR DESCRIPTION
## Summary

- add `PauliFrame.logical_observable_groups()` to expand every indexed logical-observable seed through the dependent-chain closure
- update Stim export to consume the aggregate logical-observable API, matching the existing `detector_groups()` flow
- preserve the existing raw seed storage and per-group API for backward compatibility
- document the new public API in `CHANGELOG.md`

## Why

Detector groups already have an aggregate closure-expanded accessor, while logical observables required callers to iterate over raw seeds and invoke the per-group method themselves. This API asymmetry made logical observables appear to behave differently even though both use the same closure algorithm.

## Impact

Patterns and `.ptn` files can now expose all closure-expanded logical observables with one call:

```python
pattern.pauli_frame.logical_observable_groups()
```

Existing callers of `logical_observables` and `logical_observables_group()` remain compatible.

## Validation

- `uv run ruff check graphqomb/pauli_frame.py graphqomb/stim_compiler.py tests/test_pauli_frame.py`
- `uv run --extra stim pytest -q -s tests/test_pauli_frame.py tests/test_stim_compiler.py tests/test_ptn_format.py` (92 passed)
- `git diff --check`