### PR TITLE
Add detector determinism analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Detector Determinism**: Added `PauliFrame.detector_stabilizers()` and `PauliFrame.detector_determinism()` to construct closure-expanded detector stabilizers and report whether their Pauli operators match the assigned measurement axes, including Pauli input initialization and unmeasured-output handling.
 - **Pauli Frame Logical Observables**: Added `PauliFrame.logical_observable_groups()` to return all indexed logical observables after dependent-chain expansion, matching the all-groups behavior of `detector_groups()`; Stim export now uses the new aggregate API.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Detector Determinism**: Added `PauliFrame.detector_stabilizers()` and `PauliFrame.detector_determinism()` to construct closure-expanded detector stabilizers and report whether their Pauli operators match the assigned measurement axes, including Pauli input initialization and unmeasured-output handling.
+- **Detector Determinism**: Added `PauliFrame.detector_stabilizers()` and `PauliFrame.detector_determinism()` to construct closure-expanded detector stabilizers and report whether they exactly match the unsigned product of assigned Pauli measurement axes on the detector support, including Pauli input initialization and unmeasured-output handling.
 - **Pauli Frame Logical Observables**: Added `PauliFrame.logical_observable_groups()` to return all indexed logical observables after dependent-chain expansion, matching the all-groups behavior of `detector_groups()`; Stim export now uses the new aggregate API.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Detector Determinism**: Added `PauliFrame.detector_stabilizers()` and `PauliFrame.detector_determinism()` to construct closure-expanded detector stabilizers and report whether they exactly match the unsigned product of assigned Pauli measurement axes on the detector support, including Pauli input initialization and unmeasured-output handling.
+- **Detector Determinism**: Added `PauliFrame.detector_stabilizers()` and `PauliFrame.detector_determinism()` to construct closure-expanded detector stabilizers and report whether they exactly match the unsigned product of assigned Pauli measurement axes on the detector support. The construction respects Pauli input initialization, replaces Z-measured graph stabilizers with single-qubit Z, removes their incident graph edges, and omits unmeasured outputs from comparison.
 - **Pauli Frame Logical Observables**: Added `PauliFrame.logical_observable_groups()` to return all indexed logical observables after dependent-chain expansion, matching the all-groups behavior of `detector_groups()`; Stim export now uses the new aggregate API.
 
 ### Fixed

--- a/graphqomb/pauli_frame.py
+++ b/graphqomb/pauli_frame.py
@@ -200,27 +200,57 @@ class PauliFrame:
     def detector_determinism(self) -> list[bool]:
         r"""Determine whether each detector has deterministic measurement parity.
 
-        A detector is deterministic when every non-identity Pauli operator in
-        its stabilizer agrees with the corresponding Pauli measurement axis.
-        Output nodes without an assigned measurement basis are omitted from the
-        comparison.
+        A detector is deterministic when its stabilizer is exactly equal to the
+        product of the Pauli measurement axes on its detector group.  Measurement
+        signs and output nodes without an assigned measurement basis are omitted
+        from the comparison.
 
         Returns
         -------
         `list`\[`bool`\]
             Determinism flags in the same order as `detector_groups`.
         """
+        groups = self.detector_groups()
+        stabilizers = [self._detector_stabilizer(group) for group in groups]
+        unmeasured_outputs = self.graphstate.output_node_indices.keys() - self.graphstate.meas_bases.keys()
+        results: list[bool] = []
+
+        for group, stabilizer in zip(groups, stabilizers, strict=True):
+            compared_stabilizer = {
+                node: axis for node, axis in stabilizer.items() if node not in unmeasured_outputs
+            }
+            measurement_product = self._detector_measurement_product(group)
+            results.append(measurement_product is not None and compared_stabilizer == measurement_product)
+
+        return results
+
+    def _detector_measurement_product(self, detector_group: AbstractSet[int]) -> dict[int, Axis] | None:
+        r"""Construct the unsigned Pauli measurement product on a detector group.
+
+        Parameters
+        ----------
+        detector_group : `collections.abc.Set`\[`int`\]
+            Closure-expanded detector group.
+
+        Returns
+        -------
+        `dict`\[`int`, `Axis`\] | `None`
+            Pauli measurement axes, or None if a compared node does not have a
+            Pauli measurement basis.
+        """
+        measurement_product: dict[int, Axis] = {}
         output_nodes = self.graphstate.output_node_indices
         meas_bases = self.graphstate.meas_bases
 
-        return [
-            all(
-                (node in output_nodes and node not in meas_bases)
-                or (node in meas_bases and determine_pauli_axis(meas_bases[node]) == pauli_axis)
-                for node, pauli_axis in stabilizer.items()
-            )
-            for stabilizer in self.detector_stabilizers()
-        ]
+        for node in detector_group:
+            meas_basis = meas_bases.get(node)
+            if meas_basis is None and node in output_nodes:
+                continue
+            if meas_basis is None or (axis := determine_pauli_axis(meas_basis)) is None:
+                return None
+            measurement_product[node] = axis
+
+        return measurement_product
 
     def _detector_stabilizer(self, detector_group: AbstractSet[int]) -> dict[int, Axis]:
         r"""Construct the product stabilizer for an expanded detector group.

--- a/graphqomb/pauli_frame.py
+++ b/graphqomb/pauli_frame.py
@@ -178,6 +178,83 @@ class PauliFrame:
 
         return groups
 
+    def detector_stabilizers(self) -> list[dict[int, Axis]]:
+        r"""Get the graph-state stabilizer associated with each detector.
+
+        The detector groups are expanded through their dependent chains before
+        constructing the stabilizers.  A non-input node contributes its graph
+        stabilizer, i.e. X on itself and Z on each neighbor.  Input nodes instead
+        contribute the stabilizer obtained from their initialization axis: X or
+        Y on themselves and Z on each neighbor, or only Z on themselves for a
+        Z-initialized input.
+
+        Global phases are discarded when multiplying the Pauli operators.
+
+        Returns
+        -------
+        `list`\[`dict`\[`int`, `Axis`\]\]
+            Detector stabilizers, represented by their non-identity Pauli axes.
+        """
+        return [self._detector_stabilizer(group) for group in self.detector_groups()]
+
+    def detector_determinism(self) -> list[bool]:
+        r"""Determine whether each detector has deterministic measurement parity.
+
+        A detector is deterministic when every non-identity Pauli operator in
+        its stabilizer agrees with the corresponding Pauli measurement axis.
+        Output nodes without an assigned measurement basis are omitted from the
+        comparison.
+
+        Returns
+        -------
+        `list`\[`bool`\]
+            Determinism flags in the same order as `detector_groups`.
+        """
+        output_nodes = self.graphstate.output_node_indices
+        meas_bases = self.graphstate.meas_bases
+
+        return [
+            all(
+                (node in output_nodes and node not in meas_bases)
+                or (node in meas_bases and determine_pauli_axis(meas_bases[node]) == pauli_axis)
+                for node, pauli_axis in stabilizer.items()
+            )
+            for stabilizer in self.detector_stabilizers()
+        ]
+
+    def _detector_stabilizer(self, detector_group: AbstractSet[int]) -> dict[int, Axis]:
+        r"""Construct the product stabilizer for an expanded detector group.
+
+        Parameters
+        ----------
+        detector_group : `collections.abc.Set`\[`int`\]
+            Closure-expanded detector group.
+
+        Returns
+        -------
+        `dict`\[`int`, `Axis`\]
+            Non-identity Pauli axes in the detector stabilizer.
+        """
+        x_support: set[int] = set()
+        z_support: set[int] = set()
+        input_axes = self.graphstate.input_initialization_axes
+
+        for node in detector_group:
+            axis = input_axes.get(node, Axis.X)
+
+            if axis in {Axis.X, Axis.Y}:
+                x_support.symmetric_difference_update({node})
+                z_support.symmetric_difference_update(self.graphstate.neighbors(node))
+            if axis in {Axis.Y, Axis.Z}:
+                z_support.symmetric_difference_update({node})
+
+        stabilizer: dict[int, Axis] = {}
+        for node in x_support | z_support:
+            has_x = node in x_support
+            has_z = node in z_support
+            stabilizer[node] = Axis.Y if has_x and has_z else Axis.X if has_x else Axis.Z
+        return stabilizer
+
     def logical_observable_groups(self) -> dict[int, set[int]]:
         r"""Get all logical observable groups after dependent-chain expansion.
 

--- a/graphqomb/pauli_frame.py
+++ b/graphqomb/pauli_frame.py
@@ -216,9 +216,7 @@ class PauliFrame:
         results: list[bool] = []
 
         for group, stabilizer in zip(groups, stabilizers, strict=True):
-            compared_stabilizer = {
-                node: axis for node, axis in stabilizer.items() if node not in unmeasured_outputs
-            }
+            compared_stabilizer = {node: axis for node, axis in stabilizer.items() if node not in unmeasured_outputs}
             measurement_product = self._detector_measurement_product(group)
             results.append(measurement_product is not None and compared_stabilizer == measurement_product)
 

--- a/graphqomb/pauli_frame.py
+++ b/graphqomb/pauli_frame.py
@@ -182,11 +182,11 @@ class PauliFrame:
         r"""Get the graph-state stabilizer associated with each detector.
 
         The detector groups are expanded through their dependent chains before
-        constructing the stabilizers.  A non-input node contributes its graph
-        stabilizer, i.e. X on itself and Z on each neighbor.  Input nodes instead
-        contribute the stabilizer obtained from their initialization axis: X or
-        Y on themselves and Z on each neighbor, or only Z on themselves for a
-        Z-initialized input.
+        constructing the stabilizers.  A Z-measured node contributes Z only on
+        itself and is removed from the neighbor sets of all other graph
+        stabilizers.  Every other non-input node contributes X on itself and Z
+        on each remaining neighbor.  Input nodes instead contribute the
+        stabilizer obtained from their initialization axis.
 
         Global phases are discarded when multiplying the Pauli operators.
 
@@ -195,7 +195,8 @@ class PauliFrame:
         `list`\[`dict`\[`int`, `Axis`\]\]
             Detector stabilizers, represented by their non-identity Pauli axes.
         """
-        return [self._detector_stabilizer(group) for group in self.detector_groups()]
+        z_measurements = self._z_measurements()
+        return [self._detector_stabilizer(group, z_measurements=z_measurements) for group in self.detector_groups()]
 
     def detector_determinism(self) -> list[bool]:
         r"""Determine whether each detector has deterministic measurement parity.
@@ -211,7 +212,8 @@ class PauliFrame:
             Determinism flags in the same order as `detector_groups`.
         """
         groups = self.detector_groups()
-        stabilizers = [self._detector_stabilizer(group) for group in groups]
+        z_measurements = self._z_measurements()
+        stabilizers = [self._detector_stabilizer(group, z_measurements=z_measurements) for group in groups]
         unmeasured_outputs = self.graphstate.output_node_indices.keys() - self.graphstate.meas_bases.keys()
         results: list[bool] = []
 
@@ -250,13 +252,34 @@ class PauliFrame:
 
         return measurement_product
 
-    def _detector_stabilizer(self, detector_group: AbstractSet[int]) -> dict[int, Axis]:
+    def _z_measurements(self) -> set[int]:
+        r"""Return all nodes assigned a Z measurement.
+
+        Returns
+        -------
+        `set`\[`int`\]
+            Nodes with a Z measurement basis.
+        """
+        return {
+            node
+            for node, meas_basis in self.graphstate.meas_bases.items()
+            if determine_pauli_axis(meas_basis) is Axis.Z
+        }
+
+    def _detector_stabilizer(
+        self,
+        detector_group: AbstractSet[int],
+        *,
+        z_measurements: AbstractSet[int],
+    ) -> dict[int, Axis]:
         r"""Construct the product stabilizer for an expanded detector group.
 
         Parameters
         ----------
         detector_group : `collections.abc.Set`\[`int`\]
             Closure-expanded detector group.
+        z_measurements : `collections.abc.Set`\[`int`\]
+            Nodes removed by Z measurements.
 
         Returns
         -------
@@ -268,11 +291,15 @@ class PauliFrame:
         input_axes = self.graphstate.input_initialization_axes
 
         for node in detector_group:
+            if node in z_measurements:
+                z_support.symmetric_difference_update({node})
+                continue
+
             axis = input_axes.get(node, Axis.X)
 
             if axis in {Axis.X, Axis.Y}:
                 x_support.symmetric_difference_update({node})
-                z_support.symmetric_difference_update(self.graphstate.neighbors(node))
+                z_support.symmetric_difference_update(self.graphstate.neighbors(node) - z_measurements)
             if axis in {Axis.Y, Axis.Z}:
                 z_support.symmetric_difference_update({node})
 

--- a/tests/test_pauli_frame.py
+++ b/tests/test_pauli_frame.py
@@ -6,7 +6,7 @@ import math
 
 import pytest
 
-from graphqomb.common import Axis, Plane, PlannerMeasBasis
+from graphqomb.common import Axis, AxisMeasBasis, Plane, PlannerMeasBasis, Sign
 from graphqomb.graphstate import GraphState
 from graphqomb.pauli_frame import PauliFrame
 
@@ -374,6 +374,81 @@ def test_detector_groups() -> None:
 
     assert groups[0] == {n1}
     assert groups[1] == {n0, n1, n2}  # n0 is included via dependent chain
+
+
+def test_detector_stabilizer_and_determinism() -> None:
+    """A detector stabilizer is the product of graph-state stabilizers."""
+    graph = GraphState()
+    center = graph.add_node()
+    measured_neighbor = graph.add_node()
+    unmeasured_output = graph.add_node()
+
+    graph.register_output(unmeasured_output, 0)
+    graph.add_edge(center, measured_neighbor)
+    graph.add_edge(center, unmeasured_output)
+    graph.assign_meas_basis(center, AxisMeasBasis(Axis.X, Sign.PLUS))
+    graph.assign_meas_basis(measured_neighbor, AxisMeasBasis(Axis.Z, Sign.PLUS))
+
+    pframe = PauliFrame(graph, xflow={}, zflow={}, parity_check_group=[{center}])
+
+    assert pframe.detector_stabilizers() == [
+        {
+            center: Axis.X,
+            measured_neighbor: Axis.Z,
+            unmeasured_output: Axis.Z,
+        }
+    ]
+    assert pframe.detector_determinism() == [True]
+
+    # Once the output is measured, its basis participates in the comparison.
+    graph.assign_meas_basis(unmeasured_output, AxisMeasBasis(Axis.X, Sign.PLUS))
+    assert pframe.detector_determinism() == [False]
+
+
+def test_detector_stabilizer_multiplication() -> None:
+    """Overlapping X and Z support multiplies to Y up to phase."""
+    graph = GraphState()
+    n0 = graph.add_node()
+    n1 = graph.add_node()
+    graph.add_edge(n0, n1)
+    graph.assign_meas_basis(n0, AxisMeasBasis(Axis.Y, Sign.PLUS))
+    graph.assign_meas_basis(n1, AxisMeasBasis(Axis.Y, Sign.MINUS))
+
+    pframe = PauliFrame(graph, xflow={}, zflow={}, parity_check_group=[{n0, n1}])
+
+    assert pframe.detector_stabilizers() == [{n0: Axis.Y, n1: Axis.Y}]
+    assert pframe.detector_determinism() == [True]
+
+    graph.assign_meas_basis(n1, AxisMeasBasis(Axis.X, Sign.PLUS))
+    assert pframe.detector_determinism() == [False]
+
+
+@pytest.mark.parametrize(
+    ("init_axis", "expected_stabilizer"),
+    [
+        (Axis.X, {0: Axis.X, 1: Axis.Z}),
+        (Axis.Y, {0: Axis.Y, 1: Axis.Z}),
+        (Axis.Z, {0: Axis.Z}),
+    ],
+)
+def test_input_detector_stabilizer(
+    init_axis: Axis,
+    expected_stabilizer: dict[int, Axis],
+) -> None:
+    """Input detector stabilizers respect their preparation axes."""
+    graph = GraphState()
+    input_node = graph.add_node()
+    neighbor = graph.add_node()
+    graph.register_input(input_node, 0, init_axis=init_axis)
+    graph.add_edge(input_node, neighbor)
+    graph.assign_meas_basis(input_node, AxisMeasBasis(init_axis, Sign.PLUS))
+    graph.assign_meas_basis(neighbor, AxisMeasBasis(Axis.Z, Sign.PLUS))
+
+    pframe = PauliFrame(graph, xflow={}, zflow={}, parity_check_group=[{input_node}])
+
+    assert (input_node, neighbor) == (0, 1)
+    assert pframe.detector_stabilizers() == [expected_stabilizer]
+    assert pframe.detector_determinism() == [True]
 
 
 def test_logical_observables_group() -> None:

--- a/tests/test_pauli_frame.py
+++ b/tests/test_pauli_frame.py
@@ -408,12 +408,27 @@ def test_detector_determinism_requires_exact_support() -> None:
     outside_node = graph.add_node()
     graph.add_edge(detector_node, outside_node)
     graph.assign_meas_basis(detector_node, AxisMeasBasis(Axis.X, Sign.PLUS))
-    graph.assign_meas_basis(outside_node, AxisMeasBasis(Axis.Z, Sign.PLUS))
+    graph.assign_meas_basis(outside_node, AxisMeasBasis(Axis.X, Sign.PLUS))
 
     pframe = PauliFrame(graph, xflow={}, zflow={}, parity_check_group=[{detector_node}])
 
     assert pframe.detector_stabilizers() == [{detector_node: Axis.X, outside_node: Axis.Z}]
     assert pframe.detector_determinism() == [False]
+
+
+def test_z_measurement_replaces_graph_stabilizer_and_incident_edges() -> None:
+    """A Z-measured node contributes Z alone and is removed from neighbor sets."""
+    graph = GraphState()
+    x_node = graph.add_node()
+    z_node = graph.add_node()
+    graph.add_edge(x_node, z_node)
+    graph.assign_meas_basis(x_node, AxisMeasBasis(Axis.X, Sign.PLUS))
+    graph.assign_meas_basis(z_node, AxisMeasBasis(Axis.Z, Sign.MINUS))
+
+    pframe = PauliFrame(graph, xflow={}, zflow={}, parity_check_group=[{x_node, z_node}])
+
+    assert pframe.detector_stabilizers() == [{x_node: Axis.X, z_node: Axis.Z}]
+    assert pframe.detector_determinism() == [True]
 
 
 def test_detector_stabilizer_multiplication() -> None:
@@ -437,8 +452,8 @@ def test_detector_stabilizer_multiplication() -> None:
 @pytest.mark.parametrize(
     ("init_axis", "expected_stabilizer", "expected_determinism"),
     [
-        (Axis.X, {0: Axis.X, 1: Axis.Z}, False),
-        (Axis.Y, {0: Axis.Y, 1: Axis.Z}, False),
+        (Axis.X, {0: Axis.X}, True),
+        (Axis.Y, {0: Axis.Y}, True),
         (Axis.Z, {0: Axis.Z}, True),
     ],
 )
@@ -463,8 +478,8 @@ def test_input_detector_stabilizer(
     assert pframe.detector_determinism() == [expected_determinism]
 
 
-def test_detector_determinism_detects_canceled_support() -> None:
-    """A detector node canceled to identity makes the Pauli products unequal."""
+def test_z_measurement_prevents_incident_support_cancellation() -> None:
+    """Removing Z-measured nodes from neighbor sets prevents support cancellation."""
     graph = GraphState()
     z_input = graph.add_node()
     neighbor = graph.add_node()
@@ -475,7 +490,20 @@ def test_detector_determinism_detects_canceled_support() -> None:
 
     pframe = PauliFrame(graph, xflow={}, zflow={}, parity_check_group=[{z_input, neighbor}])
 
-    assert pframe.detector_stabilizers() == [{neighbor: Axis.X}]
+    assert pframe.detector_stabilizers() == [{z_input: Axis.Z, neighbor: Axis.X}]
+    assert pframe.detector_determinism() == [True]
+
+
+def test_input_initialization_can_make_detector_non_deterministic() -> None:
+    """A detector is non-deterministic when its measurement disagrees with input preparation."""
+    graph = GraphState()
+    z_input = graph.add_node()
+    graph.register_input(z_input, 0, init_axis=Axis.Z)
+    graph.assign_meas_basis(z_input, AxisMeasBasis(Axis.X, Sign.PLUS))
+
+    pframe = PauliFrame(graph, xflow={}, zflow={}, parity_check_group=[{z_input}])
+
+    assert pframe.detector_stabilizers() == [{z_input: Axis.Z}]
     assert pframe.detector_determinism() == [False]
 
 

--- a/tests/test_pauli_frame.py
+++ b/tests/test_pauli_frame.py
@@ -380,21 +380,17 @@ def test_detector_stabilizer_and_determinism() -> None:
     """A detector stabilizer is the product of graph-state stabilizers."""
     graph = GraphState()
     center = graph.add_node()
-    measured_neighbor = graph.add_node()
     unmeasured_output = graph.add_node()
 
     graph.register_output(unmeasured_output, 0)
-    graph.add_edge(center, measured_neighbor)
     graph.add_edge(center, unmeasured_output)
     graph.assign_meas_basis(center, AxisMeasBasis(Axis.X, Sign.PLUS))
-    graph.assign_meas_basis(measured_neighbor, AxisMeasBasis(Axis.Z, Sign.PLUS))
 
     pframe = PauliFrame(graph, xflow={}, zflow={}, parity_check_group=[{center}])
 
     assert pframe.detector_stabilizers() == [
         {
             center: Axis.X,
-            measured_neighbor: Axis.Z,
             unmeasured_output: Axis.Z,
         }
     ]
@@ -402,6 +398,21 @@ def test_detector_stabilizer_and_determinism() -> None:
 
     # Once the output is measured, its basis participates in the comparison.
     graph.assign_meas_basis(unmeasured_output, AxisMeasBasis(Axis.X, Sign.PLUS))
+    assert pframe.detector_determinism() == [False]
+
+
+def test_detector_determinism_requires_exact_support() -> None:
+    """A matching measurement outside the detector group cannot extend its product."""
+    graph = GraphState()
+    detector_node = graph.add_node()
+    outside_node = graph.add_node()
+    graph.add_edge(detector_node, outside_node)
+    graph.assign_meas_basis(detector_node, AxisMeasBasis(Axis.X, Sign.PLUS))
+    graph.assign_meas_basis(outside_node, AxisMeasBasis(Axis.Z, Sign.PLUS))
+
+    pframe = PauliFrame(graph, xflow={}, zflow={}, parity_check_group=[{detector_node}])
+
+    assert pframe.detector_stabilizers() == [{detector_node: Axis.X, outside_node: Axis.Z}]
     assert pframe.detector_determinism() == [False]
 
 
@@ -424,16 +435,17 @@ def test_detector_stabilizer_multiplication() -> None:
 
 
 @pytest.mark.parametrize(
-    ("init_axis", "expected_stabilizer"),
+    ("init_axis", "expected_stabilizer", "expected_determinism"),
     [
-        (Axis.X, {0: Axis.X, 1: Axis.Z}),
-        (Axis.Y, {0: Axis.Y, 1: Axis.Z}),
-        (Axis.Z, {0: Axis.Z}),
+        (Axis.X, {0: Axis.X, 1: Axis.Z}, False),
+        (Axis.Y, {0: Axis.Y, 1: Axis.Z}, False),
+        (Axis.Z, {0: Axis.Z}, True),
     ],
 )
 def test_input_detector_stabilizer(
     init_axis: Axis,
     expected_stabilizer: dict[int, Axis],
+    expected_determinism: bool,
 ) -> None:
     """Input detector stabilizers respect their preparation axes."""
     graph = GraphState()
@@ -448,7 +460,23 @@ def test_input_detector_stabilizer(
 
     assert (input_node, neighbor) == (0, 1)
     assert pframe.detector_stabilizers() == [expected_stabilizer]
-    assert pframe.detector_determinism() == [True]
+    assert pframe.detector_determinism() == [expected_determinism]
+
+
+def test_detector_determinism_detects_canceled_support() -> None:
+    """A detector node canceled to identity makes the Pauli products unequal."""
+    graph = GraphState()
+    z_input = graph.add_node()
+    neighbor = graph.add_node()
+    graph.register_input(z_input, 0, init_axis=Axis.Z)
+    graph.add_edge(z_input, neighbor)
+    graph.assign_meas_basis(z_input, AxisMeasBasis(Axis.Z, Sign.PLUS))
+    graph.assign_meas_basis(neighbor, AxisMeasBasis(Axis.X, Sign.PLUS))
+
+    pframe = PauliFrame(graph, xflow={}, zflow={}, parity_check_group=[{z_input, neighbor}])
+
+    assert pframe.detector_stabilizers() == [{neighbor: Axis.X}]
+    assert pframe.detector_determinism() == [False]
 
 
 def test_logical_observables_group() -> None:


### PR DESCRIPTION
## Summary

- construct a graph-state stabilizer for each closure-expanded detector group
- report a detector as deterministic only when that stabilizer exactly equals the unsigned product of Pauli measurement axes on the detector support
- replace each Z-measured graph stabilizer with single-qubit Z and remove Z-measured vertices from all other stabilizer neighbor sets
- respect X/Y/Z input initialization and omit outputs without measurement bases from both sides of the comparison
- document the new APIs in the changelog

## Why

Detector parity is deterministic when the measured Pauli product itself is a stabilizer. Comparing only per-qubit axes or treating Z-measured vertices as ordinary X-with-neighbor-Z graph stabilizers produces incorrect results, especially for terminal Y/Z data-readout closure detectors.

## Impact

`PauliFrame.detector_stabilizers()` exposes the non-identity Pauli support for each detector, and `PauliFrame.detector_determinism()` returns aligned exact-product determinism flags. Measurement signs are intentionally ignored.

## Validation

- `pytest -s -q` (811 passed, 1 skipped)
- `ruff check graphqomb tests examples`
- `ruff format --check --diff`
- `mypy graphqomb/pauli_frame.py`
- `pyright graphqomb/pauli_frame.py`
- all 15 noiseless FTQC compiler survey triangle-memory circuits (X/Y/Z, d=3/5/7/9/11): every original detector classified deterministic
- injected `DETECTOR rec[-1]`: classified non-deterministic while all original detectors remain deterministic