### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-23
+
 ### Added
 
 - **Detector Determinism**: Added `PauliFrame.detector_stabilizers()` and `PauliFrame.detector_determinism()` to construct closure-expanded detector stabilizers and report whether they exactly match the unsigned product of assigned Pauli measurement axes on the detector support. The construction respects Pauli input initialization, replaces Z-measured graph stabilizers with single-qubit Z, removes their incident graph edges, and omits unmeasured outputs from comparison.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graphqomb"
-version = "0.4.1"
+version = "0.4.2"
 description = "A modular Graph State qompiler for measurement-based quantum computing."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -704,7 +704,7 @@ wheels = [
 
 [[package]]
 name = "graphqomb"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary

- bump the GraphQOMB package version from 0.4.1 to 0.4.2
- add the 0.4.2 release date and detector determinism changes to the changelog
- keep `uv.lock` aligned with the package metadata

## Impact

This prepares the detector determinism work currently on `master` for the v0.4.2 package release.

## Validation

- `uv lock --check`
- installed package metadata reports `0.4.2`
- `uv run --extra stim pytest -q` (`811 passed, 1 skipped`)
- `git diff --check origin/master...HEAD`