### PR TITLE
Import Stim classical feedback flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Stim Classical Feedback Import**: Import measurement-record-controlled `CX`, `CY`, `CZ`, `XCZ`, and `YCZ` targets into the pattern's X/Z correction flows, preserving instruction position and applying the feedback only after graph-derived odd-neighbor Z-flow construction.
+
 ## [0.4.2] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Stim Classical Feedback Import**: Import measurement-record-controlled `CX`, `CY`, `CZ`, `XCZ`, and `YCZ` targets into the pattern's X/Z correction flows, preserving instruction position and applying the feedback only after graph-derived odd-neighbor Z-flow construction. Because frame corrections are applied at the target's measurement, an X or Y feedback entry also XORs Z corrections onto the neighbors entangled with the target after the feedback position; neighbors entangled before the feedback receive no compensation, and Z feedback needs none.
 
+### Changed
+
+- **First-Class Measured Outputs**: Output nodes with an assigned measurement basis are now scheduled and executed like ordinary measurements instead of being appended after the timeline. `dag_from_flow` keeps correction-flow dependencies whose source is a measured output, the `Scheduler`, CP-SAT solver, and both greedy schedulers include measured outputs in `measure_time`, `qompile` emits their `M` commands inside the scheduled slices, and `PatternSimulator` applies their feedforward corrections via `meas_flip`. This makes classical feedback sourced from direct Stim measurements causal and correctly simulated. Manual schedules must now provide measurement times for measured outputs. Added `unmeasured_output_nodes()` to `graphqomb.graphstate`, and `compose()` now rejects connecting through a measured output of the first graph because the wire is consumed by the readout.
+
 ## [0.4.2] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Stim Classical Feedback Import**: Import measurement-record-controlled `CX`, `CY`, `CZ`, `XCZ`, and `YCZ` targets into the pattern's X/Z correction flows, preserving instruction position and applying the feedback only after graph-derived odd-neighbor Z-flow construction.
+- **Stim Classical Feedback Import**: Import measurement-record-controlled `CX`, `CY`, `CZ`, `XCZ`, and `YCZ` targets into the pattern's X/Z correction flows, preserving instruction position and applying the feedback only after graph-derived odd-neighbor Z-flow construction. Because frame corrections are applied at the target's measurement, an X or Y feedback entry also XORs Z corrections onto the neighbors entangled with the target after the feedback position; neighbors entangled before the feedback receive no compensation, and Z feedback needs none.
 
 ## [0.4.2] - 2026-07-23
 

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -30,7 +30,8 @@ The lowered pattern combines:
 
 Most scheduled work is serialized as prepare, entangle, and measure commands separated by ``TICK`` slice boundaries.
 Pauli corrections are retained in the :class:`graphqomb.pauli_frame.PauliFrame` rather than emitted as ``X``/``Z`` commands, so the executable command stream is limited to ``N``, ``E``, ``M``, and ``TICK``.
-The pattern simulator materializes pending output-frame corrections when returning an output statevector or an explicit output measurement result.
+Output nodes with an assigned measurement basis are projective readouts of the output register: they are scheduled and measured inside the timeline like any other node, and their results participate in feedforward.
+Outputs without a basis remain quantum, and the pattern simulator materializes their pending frame corrections when returning an output statevector.
 
 Feedforward and causality
 -------------------------

--- a/docs/source/graphstate.rst
+++ b/docs/source/graphstate.rst
@@ -24,6 +24,7 @@ Functions
 .. autofunction:: graphqomb.graphstate.compose
 .. autofunction:: graphqomb.graphstate.bipartite_edges
 .. autofunction:: graphqomb.graphstate.odd_neighbors
+.. autofunction:: graphqomb.graphstate.unmeasured_output_nodes
 
 Auxiliary Classes
 ------------------

--- a/docs/source/stim_importer.rst
+++ b/docs/source/stim_importer.rst
@@ -68,23 +68,45 @@ unsigned ``MPP`` products. Inverted targets in ``MXX``, ``MYY``, ``MZZ``, and
 ``MPP`` are rejected because GraphQOMB does not currently retain the
 corresponding parity offset.
 
-All ``MPP`` instructions within one ``TICK`` block are represented by one
-combined extraction and are validated to commute. Anticommuting products in
-the same block are rejected. Within a combined block, local stabilizer
-interactions are ordered ``Z -> Y -> X`` on each shared data qubit. If an odd
-number of shared-data-qubit pairs reverse the order of the same two
-stabilizers, the graph-state builder adds the required CZ edge between their
-ancillas. This rule is applied automatically for both Type I and Type II
-foliation.
+Classical Pauli feedback
+------------------------
 
-Only data-wire nodes contribute to the X-correction flow; MPP ancilla nodes do
-not produce X corrections. After composing all graph fragments, the importer
-derives the Z-correction flow from the odd neighborhood of the complete
-X-correction flow. Both correction maps are passed directly to ``qompile()``
-without Pauli simplification or an importer-specific fallback. Non-commuting
-measurements must be separated by ``TICK`` in the source circuit. Each unit has
-a distinct unmeasured output layer, which is composed with the next unitary or
-measurement fragment by qubit index. Pass
+Stim measurement-record controls are imported as explicit Pauli-frame
+corrections. ``CX rec[-k] q``/``CNOT rec[-k] q`` adds ``q`` to the
+controlling measurement node's X-correction flow, ``CZ rec[-k] q`` adds it to
+the Z-correction flow, and ``CY rec[-k] q`` adds it to both. The equivalent
+reverse-target spellings ``XCZ q rec[-k]`` and ``YCZ q rec[-k]`` are also
+supported, as is the symmetric ``CZ q rec[-k]`` form. Batched target pairs in
+one Stim instruction are supported when every pair is a feedback pair. Mixing
+quantum and feedback pairs in one instruction remains unsupported; use
+separate instructions.
+
+A feedback instruction is a graph-fragment boundary, so its correction targets
+the data-lane node at that exact circuit position. Repeating the same
+record-controlled Pauli correction cancels by parity. A feedback record must
+refer to an earlier imported measurement; records idealized to zero produce no
+correction.
+
+All ``MPP`` instructions within each feedback-free portion of one ``TICK``
+block are represented by one combined extraction and are validated to commute.
+Anticommuting products in the same portion are rejected. Within a combined
+block, local stabilizer interactions are ordered ``Z -> Y -> X`` on each
+shared data qubit. If an odd number of shared-data-qubit pairs reverse the
+order of the same two stabilizers, the graph-state builder adds the required CZ
+edge between their ancillas. This rule is applied automatically for both Type
+I and Type II foliation.
+
+Only data-wire nodes contribute to the graph-generated X-correction flow; MPP
+ancilla nodes do not produce those corrections. After composing all graph
+fragments, the importer first derives the Z-correction flow from the odd
+neighborhood of this graph-generated X flow. It then XORs Stim's explicit
+classical X/Y/Z feedback into the two correction maps. In particular, an
+imported CNOT feedback entry does not create an odd-neighbor Z correction.
+Both completed maps are passed directly to ``qompile()`` without Pauli
+simplification or an importer-specific fallback. Non-commuting measurements
+must be separated by ``TICK`` in the source circuit. Each unit has a distinct
+unmeasured output layer, which is composed with the next unitary or measurement
+fragment by qubit index. Pass
 ``y_foliation=YFoliation.TYPE_II`` to any of the three import entry points to use
 the three-layer Y-measurement construction; Type I is the default.
 

--- a/docs/source/stim_importer.rst
+++ b/docs/source/stim_importer.rst
@@ -87,6 +87,13 @@ record-controlled Pauli correction cancels by parity. A feedback record must
 refer to an earlier imported measurement; records idealized to zero produce no
 correction.
 
+Frame corrections are applied at their target's measurement, after every graph
+edge on the target exists. An X or Y feedback therefore also XORs Z
+corrections onto the neighbors the target becomes entangled with after the
+feedback position, which is what pushing the deferred X through those later CZ
+edges leaves behind. Neighbors entangled before the feedback position receive
+no compensation, and Z feedback commutes with CZ so it needs none.
+
 All ``MPP`` instructions within each feedback-free portion of one ``TICK``
 block are represented by one combined extraction and are validated to commute.
 Anticommuting products in the same portion are rejected. Within a combined
@@ -100,8 +107,9 @@ Only data-wire nodes contribute to the graph-generated X-correction flow; MPP
 ancilla nodes do not produce those corrections. After composing all graph
 fragments, the importer first derives the Z-correction flow from the odd
 neighborhood of this graph-generated X flow. It then XORs Stim's explicit
-classical X/Y/Z feedback into the two correction maps. In particular, an
-imported CNOT feedback entry does not create an odd-neighbor Z correction.
+classical X/Y/Z feedback into the two correction maps, including the
+deferred-X compensation described above; a feedback entry never adopts the
+full odd-neighbor rule, only the neighbors entangled after its position.
 Both completed maps are passed directly to ``qompile()`` without Pauli
 simplification or an importer-specific fallback. Non-commuting measurements
 must be separated by ``TICK`` in the source circuit. Each unit has a distinct

--- a/docs/source/stim_importer.rst
+++ b/docs/source/stim_importer.rst
@@ -94,6 +94,11 @@ feedback position, which is what pushing the deferred X through those later CZ
 edges leaves behind. Neighbors entangled before the feedback position receive
 no compensation, and Z feedback commutes with CZ so it needs none.
 
+A feedback record may come from an ``MPP`` ancilla or from a direct
+single-qubit measurement. Direct measurements are imported as measured output
+nodes, which are scheduled like ordinary measurements, so the controlling
+readout is always measured before any node that depends on its correction.
+
 All ``MPP`` instructions within each feedback-free portion of one ``TICK``
 block are represented by one combined extraction and are validated to commute.
 Anticommuting products in the same portion are rejected. Within a combined

--- a/graphqomb/feedforward.py
+++ b/graphqomb/feedforward.py
@@ -21,7 +21,7 @@ from typing import Any, TypeGuard
 import typing_extensions
 
 from graphqomb.common import Axis, Plane, determine_pauli_axis
-from graphqomb.graphstate import BaseGraphState, odd_neighbors
+from graphqomb.graphstate import BaseGraphState, odd_neighbors, unmeasured_output_nodes
 
 TOPO_ORDER_CYCLE_ERROR_MSG = "No nodes can be measured; possible cyclic dependency or incomplete preparation."
 
@@ -85,8 +85,8 @@ def dag_from_flow(
         If the flowlike object is not a Flow or GFlow
     """  # ruff:ignore[line-too-long]
     dag: dict[int, set[int]] = {}
-    output_nodes = set(graph.output_node_indices)
-    non_output_nodes = graph.nodes - output_nodes
+    unmeasured_outputs = unmeasured_output_nodes(graph)
+    measured_nodes = graph.nodes - unmeasured_outputs
     if _is_flow(xflow):
         xflow = {node: {xflow[node]} for node in xflow}
     elif _is_gflow(xflow):
@@ -104,10 +104,10 @@ def dag_from_flow(
     else:
         msg = "Invalid zflow object"
         raise TypeError(msg)
-    for node in non_output_nodes:
+    for node in measured_nodes:
         target_nodes = (xflow.get(node, set()) | zflow.get(node, set())) - {node}  # remove self-loops
         dag[node] = target_nodes
-    for output in output_nodes:
+    for output in unmeasured_outputs:
         dag[output] = set()
 
     return dag

--- a/graphqomb/graphstate.py
+++ b/graphqomb/graphstate.py
@@ -9,6 +9,7 @@ This module provides:
 - `compose`: Function to compose two graph states sequentially.
 - `bipartite_edges`: Function to create a complete bipartite graph between two sets of nodes.
 - `odd_neighbors`: Function to get odd neighbors of a node.
+- `unmeasured_output_nodes`: Function to get output nodes without a measurement basis.
 
 """
 
@@ -1035,6 +1036,7 @@ def compose(  # ruff:ignore[complex-structure, too-many-branches]
     ValueError
         1. If the graph states are not in canonical form.
         2. If there are qindex conflicts (same qindex used in both graphs but not for connection).
+        3. If a connected qindex refers to a measured output of graph1.
     """
     graph1.check_canonical_form()
     graph2.check_canonical_form()
@@ -1054,6 +1056,17 @@ def compose(  # ruff:ignore[complex-structure, too-many-branches]
             f"Qindex conflicts detected: {conflicting_q_indices}. "
             "These indices are used in both graphs but cannot be connected."
         )
+        raise ValueError(msg)
+
+    # A measured output is a projective readout: the wire is consumed and
+    # cannot be continued by a following graph.
+    measured_connection_q_indices = sorted(
+        q_index
+        for node, q_index in graph1.output_node_indices.items()
+        if q_index in target_q_indices and node in graph1.meas_bases
+    )
+    if measured_connection_q_indices:
+        msg = f"Cannot compose through measured output qubit indices: {measured_connection_q_indices}."
         raise ValueError(msg)
 
     composed_graph = GraphState()
@@ -1197,3 +1210,23 @@ def odd_neighbors(nodes: AbstractSet[int], graphstate: BaseGraphState) -> set[in
         set of odd neighbors
     """
     return functools.reduce(operator.xor, (graphstate.neighbors(node) for node in nodes), set())  # pyright: ignore[reportUnknownArgumentType]
+
+
+def unmeasured_output_nodes(graphstate: BaseGraphState) -> set[int]:
+    r"""Return the output nodes without an assigned measurement basis.
+
+    Output nodes with a measurement basis are projective readouts of the output
+    register: they are scheduled and measured like any other node, while the
+    returned unmeasured outputs remain quantum.
+
+    Parameters
+    ----------
+    graphstate : `BaseGraphState`
+        graph state
+
+    Returns
+    -------
+    `set`\[`int`\]
+        set of output nodes without a measurement basis
+    """
+    return graphstate.output_node_indices.keys() - graphstate.meas_bases.keys()

--- a/graphqomb/greedy_scheduler.py
+++ b/graphqomb/greedy_scheduler.py
@@ -17,6 +17,7 @@ import itertools
 from typing import TYPE_CHECKING
 
 from graphqomb.feedforward import TOPO_ORDER_CYCLE_ERROR_MSG, inverse_dag_from_dag, topo_order_from_inv_dag
+from graphqomb.graphstate import unmeasured_output_nodes
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -64,9 +65,9 @@ def greedy_minimize_time(  # ruff:ignore[too-many-locals]
         If the scheduling cannot proceed due to cyclic dependencies
         or if the max_qubit_count constraint is too tight to allow any progress.
     """
-    unmeasured = graph.nodes - graph.output_node_indices.keys()
+    unmeasured_outputs = unmeasured_output_nodes(graph)
+    unmeasured = graph.nodes - unmeasured_outputs
     input_nodes = set(graph.input_node_indices.keys())
-    output_nodes = set(graph.output_node_indices.keys())
 
     inv_dag = inverse_dag_from_dag(dag, graph.nodes)
 
@@ -91,7 +92,7 @@ def greedy_minimize_time(  # ruff:ignore[too-many-locals]
         raise RuntimeError(msg)
 
     # Compute criticality for prioritizing preparations
-    criticality = _compute_criticality(dag, output_nodes)
+    criticality = _compute_criticality(dag, unmeasured_outputs)
 
     current_time = 0
 
@@ -296,7 +297,7 @@ def _phase2_prepare_nodes_with_slack(  # ruff:ignore[too-many-arguments]
 
 def _compute_criticality(
     dag: Mapping[int, AbstractSet[int]],
-    output_nodes: AbstractSet[int],
+    unmeasured_outputs: AbstractSet[int],
 ) -> dict[int, int]:
     # Compute criticality (remaining DAG depth) for each node.
     # Nodes with higher criticality should be prioritized for unblocking.
@@ -310,8 +311,8 @@ def _compute_criticality(
         children_crits = [criticality.get(c, 0) for c in dag.get(node, ())]
         criticality[node] = 1 + max(children_crits, default=0)
 
-    # Output nodes have criticality 0 (they don't need to be measured)
-    for node in output_nodes:
+    # Unmeasured output nodes have criticality 0 (they don't need to be measured)
+    for node in unmeasured_outputs:
         criticality[node] = 0
 
     return criticality
@@ -397,7 +398,7 @@ def greedy_minimize_space(  # ruff:ignore[too-many-locals]
     prepare_time: dict[int, int] = {}
     measure_time: dict[int, int] = {}
 
-    unmeasured = graph.nodes - graph.output_node_indices.keys()
+    unmeasured = graph.nodes - unmeasured_output_nodes(graph)
 
     inv_dag = inverse_dag_from_dag(dag, graph.nodes)
     topo_order = topo_order_from_inv_dag(inv_dag)  # from parents to children

--- a/graphqomb/qompiler.py
+++ b/graphqomb/qompiler.py
@@ -138,8 +138,6 @@ def _qompile(
         # Insert TICK between time slices
         commands.append(TICK())
 
-    commands.extend(M(node, meas_bases[node]) for node in graph.output_node_indices if node in meas_bases)
-
     # Collect input node coordinates
     input_coords = {node: graph_coords[node] for node in graph.input_node_indices if node in graph_coords}
 

--- a/graphqomb/schedule_solver.py
+++ b/graphqomb/schedule_solver.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING
 
 from ortools.sat.python import cp_model
 
+from graphqomb.graphstate import unmeasured_output_nodes
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Set as AbstractSet
@@ -62,13 +64,13 @@ def _add_constraints(
             if node in node2meas and child in node2meas:
                 model.add(node2meas[node] < node2meas[child])
 
-    # A non-input, non-output node must be prepared before it is measured.
+    # A non-input, measured node must be prepared before it is measured.
     for node in graph.nodes:
         if node in node2prep and node in node2meas:
             model.add(node2prep[node] < node2meas[node])
 
     # Edge constraints
-    for node in graph.nodes - set(graph.output_node_indices):
+    for node in node2meas:
         for neighbor in graph.neighbors(node):
             if neighbor in graph.input_node_indices:
                 if node in graph.input_node_indices:
@@ -124,7 +126,7 @@ def _compute_alive_nodes_at_time(
             ctx.model.add(p > t).only_enforce_if(a_pre.negated())
 
         a_meas = ctx.model.new_bool_var(f"alive_meas_{node}_{t}")
-        if node in ctx.graph.output_node_indices:
+        if node not in node2meas:
             ctx.model.add(a_meas == 0)
         else:
             q = node2meas[node]
@@ -211,12 +213,13 @@ def solve_schedule(
     max_time = config.max_time if config.max_time is not None else 2 * len(graph.nodes)
 
     # Create variables
+    unmeasured_outputs = unmeasured_output_nodes(graph)
     node2prep: dict[int, cp_model.IntVar] = {}
     node2meas: dict[int, cp_model.IntVar] = {}
     for node in graph.nodes:
         if node not in graph.input_node_indices:
             node2prep[node] = model.new_int_var(0, max_time, f"prep_{node}")
-        if node not in graph.output_node_indices:
+        if node not in unmeasured_outputs:
             node2meas[node] = model.new_int_var(0, max_time, f"meas_{node}")
 
     # Add constraints

--- a/graphqomb/schedule_solver.py
+++ b/graphqomb/schedule_solver.py
@@ -125,18 +125,18 @@ def _compute_alive_nodes_at_time(
             ctx.model.add(p <= t).only_enforce_if(a_pre)
             ctx.model.add(p > t).only_enforce_if(a_pre.negated())
 
-        a_meas = ctx.model.new_bool_var(f"alive_meas_{node}_{t}")
+        measured_before_t = ctx.model.new_bool_var(f"measured_before_{node}_{t}")
         if node not in node2meas:
-            ctx.model.add(a_meas == 0)
+            ctx.model.add(measured_before_t == 0)
         else:
             q = node2meas[node]
-            ctx.model.add(q <= t).only_enforce_if(a_meas)
-            ctx.model.add(q > t).only_enforce_if(a_meas.negated())
+            ctx.model.add(q < t).only_enforce_if(measured_before_t)
+            ctx.model.add(q >= t).only_enforce_if(measured_before_t.negated())
 
         alive = ctx.model.new_bool_var(f"alive_{node}_{t}")
         ctx.model.add_implication(alive, a_pre)
-        ctx.model.add_implication(alive, a_meas.negated())
-        ctx.model.add(a_pre - a_meas <= alive)
+        ctx.model.add_implication(alive, measured_before_t.negated())
+        ctx.model.add(a_pre - measured_before_t <= alive)
         alive_at_t.append(alive)
 
     return alive_at_t
@@ -150,7 +150,7 @@ def _set_minimize_space_objective(
 ) -> None:
     """Set objective to minimize the maximum number of qubits used at any time."""
     max_space = ctx.model.new_int_var(0, len(ctx.graph.nodes), "max_space")
-    for t in range(max_time):
+    for t in range(max_time + 1):
         alive_at_t = _compute_alive_nodes_at_time(ctx, node2prep, node2meas, t)
         ctx.model.add(max_space >= sum(alive_at_t))
     ctx.model.minimize(max_space)
@@ -166,7 +166,7 @@ def _set_minimize_time_objective(
     """Set objective to minimize the total execution time."""
     # Add space constraint if max_qubit_count is specified
     if max_qubit_count is not None:
-        for t in range(max_time):
+        for t in range(max_time + 1):
             alive_at_t = _compute_alive_nodes_at_time(ctx, node2prep, node2meas, t)
             ctx.model.add(sum(alive_at_t) <= max_qubit_count)
 

--- a/graphqomb/scheduler.py
+++ b/graphqomb/scheduler.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, NamedTuple
 
 from graphqomb.feedforward import dag_from_flow
+from graphqomb.graphstate import unmeasured_output_nodes
 from graphqomb.greedy_scheduler import greedy_minimize_space, greedy_minimize_time
 from graphqomb.schedule_solver import ScheduleConfig, Strategy, solve_schedule
 
@@ -152,7 +153,7 @@ class Scheduler:
         self.graph = graph
         self.dag = dag_from_flow(graph, xflow, zflow)
         self.prepare_time = dict.fromkeys(graph.nodes - graph.input_node_indices.keys())
-        self.measure_time = dict.fromkeys(graph.nodes - graph.output_node_indices.keys())
+        self.measure_time = dict.fromkeys(graph.nodes - unmeasured_output_nodes(graph))
         # Initialize entangle_time for all edges
         self.entangle_time = dict.fromkeys(graph.edges)
 
@@ -235,7 +236,7 @@ class Scheduler:
             node: prepare_time.get(node, None) for node in self.graph.nodes - self.graph.input_node_indices.keys()
         }
         self.measure_time = {
-            node: measure_time.get(node, None) for node in self.graph.nodes - self.graph.output_node_indices.keys()
+            node: measure_time.get(node, None) for node in self.graph.nodes - unmeasured_output_nodes(self.graph)
         }
         if entangle_time is not None:
             resolved_entangle_time: dict[tuple[int, int], int | None] = {}
@@ -261,7 +262,7 @@ class Scheduler:
             or if node sets do not match expected sets.
         """
         input_nodes = self.graph.input_node_indices.keys()
-        output_nodes = self.graph.output_node_indices.keys()
+        unmeasured_outputs = unmeasured_output_nodes(self.graph)
         nodes = self.graph.nodes
 
         # Input nodes should not be in prepare_time
@@ -270,15 +271,15 @@ class Scheduler:
             msg = f"Input nodes {sorted(invalid_prep)} should not be in prepare_time"
             raise ValueError(msg)
 
-        # Output nodes should not be in measure_time
-        invalid_meas = output_nodes & self.measure_time.keys()
+        # Outputs without a measurement basis should not be in measure_time
+        invalid_meas = unmeasured_outputs & self.measure_time.keys()
         if invalid_meas:
-            msg = f"Output nodes {sorted(invalid_meas)} should not be in measure_time"
+            msg = f"Unmeasured output nodes {sorted(invalid_meas)} should not be in measure_time"
             raise ValueError(msg)
 
         # Check expected node sets
         expected_prep_nodes = nodes - input_nodes
-        expected_meas_nodes = nodes - output_nodes
+        expected_meas_nodes = nodes - unmeasured_outputs
 
         if self.prepare_time.keys() != expected_prep_nodes:
             missing = expected_prep_nodes - self.prepare_time.keys()
@@ -489,9 +490,9 @@ class Scheduler:
 
         Checks:
         - Input nodes are not prepared (assumed to be prepared before time 0)
-        - Output nodes are not measured
+        - Outputs without a measurement basis are not measured
         - All non-input nodes have a preparation time
-        - All non-output nodes have a measurement time
+        - All nodes with a measurement basis have a measurement time
         - Measurement order respects DAG dependencies
         - Within same time slice, measurements happen before preparations
         - Entanglement times respect causality constraints (if entanglement is scheduled):
@@ -556,7 +557,7 @@ class Scheduler:
             node: prepare_time.get(node, None) for node in self.graph.nodes - self.graph.input_node_indices.keys()
         }
         meas_time = {
-            node: measure_time.get(node, None) for node in self.graph.nodes - self.graph.output_node_indices.keys()
+            node: measure_time.get(node, None) for node in self.graph.nodes - unmeasured_output_nodes(self.graph)
         }
 
         self.prepare_time = prep_time

--- a/graphqomb/simulator.py
+++ b/graphqomb/simulator.py
@@ -243,8 +243,8 @@ class PatternSimulator:
         if cmd.node in self.__pattern.output_node_indices:
             qindex = self.__pattern.output_node_indices[cmd.node]
             self.output_results[qindex] = result
-            return
 
+        # Measured outputs participate in feedforward like any other node.
         if result:
             self.__pattern.pauli_frame.meas_flip(cmd.node)
 

--- a/graphqomb/stim_importer.py
+++ b/graphqomb/stim_importer.py
@@ -107,6 +107,7 @@ class _FeedbackTarget:
     record_index: int
     node: int
     axis: Axis
+    past_neighbors: frozenset[int] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -189,7 +190,10 @@ def stim_circuit_to_pattern(
     probabilities are omitted because circuit-level noise is outside the
     GraphQOMB import model. Pauli measurement blocks must be separated from
     unitary blocks by TICK. Measurement-record-controlled Pauli gates are
-    imported as X/Z correction-flow entries at their circuit positions. A
+    imported as X/Z correction-flow entries at their circuit positions; an X or
+    Y feedback additionally contributes Z corrections on the neighbors its
+    target becomes entangled with after the feedback position, so deferred
+    frame-based application matches the circuit-position semantics. A
     direct single-qubit measurement terminates that qubit's lifetime; other
     qubits may continue, but the measured qubit cannot be used by a later
     operation.
@@ -997,7 +1001,7 @@ def _compose_fragments(fragments: Sequence[_Fragment]) -> _Fragment:
             | _remap_record_nodes(fragment.record_nodes, node_map2),
             feedback_targets=(
                 *_remap_feedback_targets(current.feedback_targets, node_map1),
-                *_remap_feedback_targets(fragment.feedback_targets, node_map2),
+                *_capture_feedback_targets(fragment.feedback_targets, node_map2, graph),
             ),
             mpp_extractions=(*current.mpp_extractions, *fragment.mpp_extractions),
         )
@@ -1046,6 +1050,11 @@ def _flows_with_feedback(
         source = next(iter(source_nodes))
         if feedback.axis in {Axis.X, Axis.Y}:
             xflow.setdefault(source, set()).symmetric_difference_update({feedback.node})
+            # Deferring the X to the target's measurement pushes it through the
+            # CZ edges created after the feedback position, leaving Z there.
+            deferred_z = fragment.graph.neighbors(feedback.node) - feedback.past_neighbors
+            if deferred_z:
+                zflow.setdefault(source, set()).symmetric_difference_update(deferred_z)
         if feedback.axis in {Axis.Z, Axis.Y}:
             zflow.setdefault(source, set()).symmetric_difference_update({feedback.node})
     return xflow, zflow
@@ -1109,6 +1118,25 @@ def _remap_feedback_targets(
             record_index=feedback.record_index,
             node=node_map[feedback.node],
             axis=feedback.axis,
+            past_neighbors=frozenset(node_map[node] for node in feedback.past_neighbors),
+        )
+        for feedback in feedback_targets
+    )
+
+
+def _capture_feedback_targets(
+    feedback_targets: Sequence[_FeedbackTarget],
+    node_map: Mapping[int, int],
+    graph: GraphState,
+) -> tuple[_FeedbackTarget, ...]:
+    # A feedback fragment has no internal edges, so right after composition the
+    # target's neighbors are exactly those entangled before the feedback position.
+    return tuple(
+        _FeedbackTarget(
+            record_index=feedback.record_index,
+            node=node_map[feedback.node],
+            axis=feedback.axis,
+            past_neighbors=frozenset(graph.neighbors(node_map[feedback.node])),
         )
         for feedback in feedback_targets
     )

--- a/graphqomb/stim_importer.py
+++ b/graphqomb/stim_importer.py
@@ -40,6 +40,14 @@ _RESET_AXES = {"R": Axis.Z, "RX": Axis.X, "RY": Axis.Y}
 _SINGLE_PAULI_MEASUREMENT_AXES = {"M": Axis.Z, "MX": Axis.X, "MY": Axis.Y}
 _PAIR_PAULI_MEASUREMENT_AXES = {"MXX": "X", "MYY": "Y", "MZZ": "Z"}
 _PAULI_PRODUCT_MEASUREMENT_GATES = frozenset({"MPP", *_PAIR_PAULI_MEASUREMENT_AXES})
+_FEEDBACK_AXES = {
+    ("CX", 0): Axis.X,
+    ("CY", 0): Axis.Y,
+    ("CZ", 0): Axis.Z,
+    ("CZ", 1): Axis.Z,
+    ("XCZ", 1): Axis.X,
+    ("YCZ", 1): Axis.Y,
+}
 
 
 @dataclass(frozen=True)
@@ -57,6 +65,7 @@ class _Fragment:
     graph: GraphState
     xflow: dict[int, set[int]]
     record_nodes: dict[int, int]
+    feedback_targets: tuple[_FeedbackTarget, ...] = ()
     mpp_extractions: tuple[StimMppExtraction, ...] = ()
 
 
@@ -83,6 +92,21 @@ class _AnalyzedInstruction:
     instruction: stim.CircuitInstruction
     record_indices: tuple[int, ...]
     qubit_ids: frozenset[int]
+    feedback_corrections: tuple[_FeedbackCorrection, ...]
+
+
+@dataclass(frozen=True)
+class _FeedbackCorrection:
+    record_index: int
+    stim_id: int
+    axis: Axis
+
+
+@dataclass(frozen=True)
+class _FeedbackTarget:
+    record_index: int
+    node: int
+    axis: Axis
 
 
 @dataclass(frozen=True)
@@ -164,9 +188,11 @@ def stim_circuit_to_pattern(
     states when possible. Stim noise instructions and measurement-error
     probabilities are omitted because circuit-level noise is outside the
     GraphQOMB import model. Pauli measurement blocks must be separated from
-    unitary blocks by TICK. A direct single-qubit measurement terminates that
-    qubit's lifetime; other qubits may continue, but the measured qubit cannot
-    be used by a later operation.
+    unitary blocks by TICK. Measurement-record-controlled Pauli gates are
+    imported as X/Z correction-flow entries at their circuit positions. A
+    direct single-qubit measurement terminates that qubit's lifetime; other
+    qubits may continue, but the measured qubit cannot be used by a later
+    operation.
 
     Returns
     -------
@@ -182,8 +208,7 @@ def stim_circuit_to_pattern(
         msg = "coord_dims must be 2 or 3."
         raise ValueError(msg)
 
-    flat_circuit = circuit.flattened()
-    idealized = _idealize_circuit(flat_circuit)
+    idealized = _idealize_circuit(circuit.flattened())
     normalized_circuit, stim_ids = _normalize_import_circuit(idealized.circuit)
     analysis = _CircuitAnalyzer().analyze(normalized_circuit)
     if analysis.measurement_count == 0 and (
@@ -213,10 +238,13 @@ def stim_circuit_to_pattern(
         record_nodes=fragment.record_nodes,
         zero_record_indices=idealized.zero_record_indices,
     )
+    flows = _flows_with_feedback(
+        fragment,
+        zero_record_indices=idealized.zero_record_indices,
+    )
     pattern = qompile(
         fragment.graph,
-        fragment.xflow,
-        {node: odd_neighbors(targets, fragment.graph) for node, targets in fragment.xflow.items()},
+        *flows,
         parity_check_group=parity_check_groups,
         logical_observables=logical_observables,
     )
@@ -279,14 +307,14 @@ def _normalize_import_circuit(circuit: stim.Circuit) -> tuple[stim.Circuit, froz
 
     def flush_block() -> None:
         nonlocal block, block_has_pauli_measurement, block_has_unitary
-        normalized = block
-        if block_has_unitary and not block_has_pauli_measurement:
-            try:
-                normalized = transpile(block, optimize=True)
-            except UnsupportedInstructionError as ex:
-                msg = f"Stim unitary TICK block {block_number} failed to transpile: {ex}"
-                raise UnsupportedInstructionError(msg) from ex
-        result.append(normalized)
+        result.append(
+            _normalize_tick_block(
+                block,
+                block_number=block_number,
+                has_unitary=block_has_unitary,
+                has_pauli_measurement=block_has_pauli_measurement,
+            )
+        )
         block = stim.Circuit()
         block_has_unitary = False
         block_has_pauli_measurement = False
@@ -307,7 +335,12 @@ def _normalize_import_circuit(circuit: stim.Circuit) -> tuple[stim.Circuit, froz
                     "after another quantum operation; only initial resets are supported."
                 )
                 raise ValueError(msg)
-        elif is_unitary or instruction.name == "MPP" or instruction.name in _SINGLE_PAULI_MEASUREMENT_AXES:
+        elif (
+            is_unitary
+            or _is_feedback_instruction(instruction)
+            or instruction.name == "MPP"
+            or instruction.name in _SINGLE_PAULI_MEASUREMENT_AXES
+        ):
             used_qubits.update(instruction_qubits)
 
         if instruction.name == "TICK":
@@ -323,6 +356,47 @@ def _normalize_import_circuit(circuit: stim.Circuit) -> tuple[stim.Circuit, froz
 
     flush_block()
     return result, frozenset(stim_ids)
+
+
+def _normalize_tick_block(
+    block: stim.Circuit,
+    *,
+    block_number: int,
+    has_unitary: bool,
+    has_pauli_measurement: bool,
+) -> stim.Circuit:
+    if has_unitary and has_pauli_measurement:
+        return block
+
+    subblocks: list[stim.Circuit] = []
+    current = stim.Circuit()
+    current_is_feedback: bool | None = None
+    for item in block:
+        if not isinstance(item, stim.CircuitInstruction):
+            msg = "Flattened Stim circuit unexpectedly contains a repeat block."
+            raise TypeError(msg)
+        is_feedback = _is_feedback_instruction(item)
+        if current_is_feedback is not None and is_feedback != current_is_feedback:
+            subblocks.append(current)
+            current = stim.Circuit()
+        current.append(item)
+        current_is_feedback = is_feedback
+    if len(current) or not subblocks:
+        subblocks.append(current)
+
+    result = stim.Circuit()
+    for index, subblock in enumerate(subblocks):
+        normalized = subblock
+        if any(isinstance(item, stim.CircuitInstruction) and _is_unitary_instruction(item) for item in subblock):
+            try:
+                normalized = transpile(subblock, optimize=True)
+            except UnsupportedInstructionError as ex:
+                msg = f"Stim unitary TICK block {block_number} failed to transpile: {ex}"
+                raise UnsupportedInstructionError(msg) from ex
+        result.append(normalized)
+        if index + 1 < len(subblocks):
+            result.append("TICK", [])
+    return result
 
 
 class _CircuitAnalyzer:
@@ -389,7 +463,16 @@ class _CircuitAnalyzer:
     def _record_operation(self, instruction: stim.CircuitInstruction, instruction_qubits: set[int]) -> None:
         _validate_supported_instruction(instruction)
         record_indices = tuple(range(self.measurement_count, self.measurement_count + instruction.num_measurements))
-        analyzed = _AnalyzedInstruction(instruction, record_indices, frozenset(instruction_qubits))
+        feedback_corrections = _feedback_corrections_from_instruction(
+            instruction,
+            measurement_count=self.measurement_count,
+        )
+        analyzed = _AnalyzedInstruction(
+            instruction,
+            record_indices,
+            frozenset(instruction_qubits),
+            feedback_corrections,
+        )
         self.current_block.append(analyzed)
 
         is_unitary = _is_unitary_instruction(instruction)
@@ -401,7 +484,7 @@ class _CircuitAnalyzer:
         self._record_lifetime(
             instruction,
             instruction_qubits,
-            is_quantum_operation=is_unitary or is_pauli_measurement,
+            is_quantum_operation=is_unitary or is_pauli_measurement or bool(feedback_corrections),
         )
 
         if instruction.name in _SINGLE_PAULI_MEASUREMENT_AXES:
@@ -453,6 +536,7 @@ class _CircuitAnalyzer:
 def _validate_supported_instruction(instruction: stim.CircuitInstruction) -> None:
     if (
         _is_unitary_instruction(instruction)
+        or _is_feedback_instruction(instruction)
         or instruction.name in _RESET_AXES
         or instruction.name in _SINGLE_PAULI_MEASUREMENT_AXES
         or instruction.name == "MPP"
@@ -463,7 +547,48 @@ def _validate_supported_instruction(instruction: stim.CircuitInstruction) -> Non
 
 
 def _is_unitary_instruction(instruction: stim.CircuitInstruction) -> bool:
-    return bool(stim.gate_data(instruction.name).is_unitary)
+    return bool(stim.gate_data(instruction.name).is_unitary and not _is_feedback_instruction(instruction))
+
+
+def _is_feedback_instruction(instruction: stim.CircuitInstruction) -> bool:
+    return bool(
+        stim.gate_data(instruction.name).is_unitary
+        and any(target.is_measurement_record_target for target in instruction.targets_copy())
+    )
+
+
+def _feedback_corrections_from_instruction(
+    instruction: stim.CircuitInstruction,
+    *,
+    measurement_count: int,
+) -> tuple[_FeedbackCorrection, ...]:
+    if not _is_feedback_instruction(instruction):
+        return ()
+
+    corrections: list[_FeedbackCorrection] = []
+    expected_group_size = 2
+    for group in instruction.target_groups():
+        record_positions = [index for index, target in enumerate(group) if target.is_measurement_record_target]
+        if len(group) != expected_group_size or len(record_positions) != 1:
+            msg = (
+                f"{instruction.name} feedback groups must contain exactly one measurement record and one qubit target."
+            )
+            raise ValueError(msg)
+        record_position = record_positions[0]
+        axis = _FEEDBACK_AXES.get((instruction.name, record_position))
+        if axis is None:
+            msg = f"{instruction.name} does not support a measurement record target at position {record_position}."
+            raise ValueError(msg)
+
+        target_position = 1 - record_position
+        stim_id = plain_qubit_target(group[target_position], instruction.name)
+        record_indices = record_targets_to_absolute_indices(
+            (group[record_position],),
+            measurement_count=measurement_count,
+            instruction_name=instruction.name,
+        )
+        corrections.append(_FeedbackCorrection(next(iter(record_indices)), stim_id, axis))
+    return tuple(corrections)
 
 
 def _direct_measurements_from_instruction(
@@ -540,6 +665,7 @@ def _fragments_from_blocks(
         unitary_instructions = tuple(
             analyzed.instruction for analyzed in block if _is_unitary_instruction(analyzed.instruction)
         )
+        feedback_corrections = tuple(correction for analyzed in block for correction in analyzed.feedback_corrections)
         if unitary_instructions:
             fragment, z_base = _unitary_fragment(
                 unitary_instructions,
@@ -563,6 +689,13 @@ def _fragments_from_blocks(
                     )
                 )
                 z_base += 2
+            elif feedback_corrections:
+                fragments.append(
+                    _feedback_fragment(
+                        feedback_corrections,
+                        context=context,
+                    )
+                )
             elif directly_measured_stim_ids:
                 continuing_stim_ids = live_stim_ids - directly_measured_stim_ids
                 if continuing_stim_ids:
@@ -574,6 +707,37 @@ def _fragments_from_blocks(
         live_stim_ids.difference_update(directly_measured_stim_ids)
 
     return fragments
+
+
+def _feedback_fragment(
+    corrections: Sequence[_FeedbackCorrection],
+    *,
+    context: _ImportContext,
+) -> _Fragment:
+    graph = GraphState()
+    node_by_stim_id: dict[int, int] = {}
+    for correction in corrections:
+        if correction.stim_id in node_by_stim_id:
+            continue
+        node = graph.add_node()
+        qubit = context.stim_to_qubit[correction.stim_id]
+        graph.register_input(node, qubit)
+        graph.register_output(node, qubit)
+        node_by_stim_id[correction.stim_id] = node
+
+    return _Fragment(
+        graph=graph,
+        xflow={},
+        record_nodes={},
+        feedback_targets=tuple(
+            _FeedbackTarget(
+                record_index=correction.record_index,
+                node=node_by_stim_id[correction.stim_id],
+                axis=correction.axis,
+            )
+            for correction in corrections
+        ),
+    )
 
 
 def _identity_fragment(context: _ImportContext) -> _Fragment:
@@ -831,6 +995,10 @@ def _compose_fragments(fragments: Sequence[_Fragment]) -> _Fragment:
             xflow=_remap_flow(current.xflow, node_map1) | _remap_flow(fragment.xflow, node_map2),
             record_nodes=_remap_record_nodes(current.record_nodes, node_map1)
             | _remap_record_nodes(fragment.record_nodes, node_map2),
+            feedback_targets=(
+                *_remap_feedback_targets(current.feedback_targets, node_map1),
+                *_remap_feedback_targets(fragment.feedback_targets, node_map2),
+            ),
             mpp_extractions=(*current.mpp_extractions, *fragment.mpp_extractions),
         )
     return current
@@ -854,8 +1022,33 @@ def _apply_single_measurements(
         graph=fragment.graph,
         xflow=fragment.xflow,
         record_nodes=record_nodes,
+        feedback_targets=fragment.feedback_targets,
         mpp_extractions=fragment.mpp_extractions,
     )
+
+
+def _flows_with_feedback(
+    fragment: _Fragment,
+    *,
+    zero_record_indices: frozenset[int],
+) -> tuple[dict[int, set[int]], dict[int, set[int]]]:
+    xflow = {node: set(targets) for node, targets in fragment.xflow.items()}
+    zflow = {node: odd_neighbors(targets, fragment.graph) for node, targets in fragment.xflow.items()}
+
+    for feedback in fragment.feedback_targets:
+        source_nodes = _record_indices_to_nodes(
+            frozenset({feedback.record_index}),
+            fragment.record_nodes,
+            zero_record_indices=zero_record_indices,
+        )
+        if not source_nodes:
+            continue
+        source = next(iter(source_nodes))
+        if feedback.axis in {Axis.X, Axis.Y}:
+            xflow.setdefault(source, set()).symmetric_difference_update({feedback.node})
+        if feedback.axis in {Axis.Z, Axis.Y}:
+            zflow.setdefault(source, set()).symmetric_difference_update({feedback.node})
+    return xflow, zflow
 
 
 def _measurement_annotations_from_analysis(
@@ -905,3 +1098,17 @@ def _remap_flow(flow: Mapping[int, set[int]], node_map: Mapping[int, int]) -> di
 
 def _remap_record_nodes(record_nodes: Mapping[int, int], node_map: Mapping[int, int]) -> dict[int, int]:
     return {record_index: node_map[node] for record_index, node in record_nodes.items()}
+
+
+def _remap_feedback_targets(
+    feedback_targets: Sequence[_FeedbackTarget],
+    node_map: Mapping[int, int],
+) -> tuple[_FeedbackTarget, ...]:
+    return tuple(
+        _FeedbackTarget(
+            record_index=feedback.record_index,
+            node=node_map[feedback.node],
+            axis=feedback.axis,
+        )
+        for feedback in feedback_targets
+    )

--- a/tests/test_graph_compose.py
+++ b/tests/test_graph_compose.py
@@ -139,6 +139,31 @@ def test_compose_qindex_conflict() -> None:
         compose(graph1, graph2)
 
 
+def test_compose_rejects_connection_through_measured_output() -> None:
+    """Test compose function raises error when a connected output is measured."""
+    graph1: GraphState = create_simple_graph([0], [1])
+    measured_output = next(node for node, q_index in graph1.output_node_indices.items() if q_index == 1)
+    graph1.assign_meas_basis(measured_output, PlannerMeasBasis(Plane.XY, 0.0))
+
+    graph2: GraphState = create_simple_graph([1], [2])
+
+    with pytest.raises(ValueError, match="measured output qubit indices"):
+        compose(graph1, graph2)
+
+
+def test_compose_allows_measured_output_outside_connection() -> None:
+    """Test compose function keeps measured outputs that are not connected."""
+    graph1: GraphState = create_simple_graph([0, 2], [1, 3])
+    measured_output = next(node for node, q_index in graph1.output_node_indices.items() if q_index == 3)
+    graph1.assign_meas_basis(measured_output, PlannerMeasBasis(Plane.XY, 0.0))
+
+    graph2: GraphState = create_simple_graph([1], [4])
+
+    composed, node_map1, _ = compose(graph1, graph2)
+
+    assert node_map1[measured_output] in composed.meas_bases
+
+
 def test_compose_preserves_measurement_bases() -> None:
     """Test that measurement bases are preserved during composition."""
     graph1: GraphState = GraphState()

--- a/tests/test_greedy_scheduler.py
+++ b/tests/test_greedy_scheduler.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from graphqomb.common import Plane, PlannerMeasBasis
 from graphqomb.graphstate import GraphState
 from graphqomb.greedy_scheduler import (
     greedy_minimize_space,
@@ -729,3 +730,34 @@ def test_greedy_minimize_space_prepares_remaining_tail_nodes() -> None:
     assert n1 in prepare_time
     assert n2 in prepare_time
     assert prepare_time[n2] >= prepare_time[n1]
+
+
+@pytest.mark.parametrize("strategy", [Strategy.MINIMIZE_TIME, Strategy.MINIMIZE_SPACE])
+@pytest.mark.parametrize("use_greedy", [True, False])
+def test_solve_schedule_orders_measured_output_after_dependencies(strategy: Strategy, use_greedy: bool) -> None:
+    """Measured outputs must be scheduled like ordinary measurements, after their flow parents."""
+    graph = GraphState()
+    node0 = graph.add_node()
+    node1 = graph.add_node()
+    node2 = graph.add_node()
+    graph.add_edge(node0, node1)
+    graph.add_edge(node1, node2)
+    qindex = 0
+    graph.register_input(node0, qindex)
+    graph.register_output(node2, qindex)
+    graph.assign_meas_basis(node0, PlannerMeasBasis(Plane.XY, 0.0))
+    graph.assign_meas_basis(node1, PlannerMeasBasis(Plane.XY, 0.0))
+    graph.assign_meas_basis(node2, PlannerMeasBasis(Plane.XY, 0.0))
+
+    flow = {node0: {node1}, node1: {node2}}
+    scheduler = Scheduler(graph, flow)
+
+    assert scheduler.solve_schedule(ScheduleConfig(strategy, use_greedy=use_greedy))
+    scheduler.validate_schedule()
+
+    measure_time = scheduler.measure_time
+    time0, time1, time2 = measure_time[node0], measure_time[node1], measure_time[node2]
+    assert time0 is not None
+    assert time1 is not None
+    assert time2 is not None
+    assert time0 < time1 < time2

--- a/tests/test_scheduler_integration.py
+++ b/tests/test_scheduler_integration.py
@@ -193,6 +193,25 @@ def test_space_constrained_scheduling() -> None:
     assert isinstance(success, bool)
 
 
+def test_cpsat_rejects_initial_measured_outputs_exceeding_qubit_limit() -> None:
+    """Measured inputs still occupy qubits during their measurement slice."""
+    graph = GraphState()
+    for qubit in range(2):
+        node = graph.add_node()
+        graph.register_input(node, qubit)
+        graph.register_output(node, qubit)
+        graph.assign_meas_basis(node, PlannerMeasBasis(Plane.XY, 0.0))
+
+    scheduler = Scheduler(graph, {})
+
+    success = scheduler.solve_schedule(
+        ScheduleConfig(strategy=Strategy.MINIMIZE_TIME, max_qubit_count=1),
+        timeout=10,
+    )
+
+    assert not success
+
+
 def test_schedule_compression() -> None:
     """Test that schedule compression reduces unnecessary time gaps."""
     # Create a graph

--- a/tests/test_scheduler_integration.py
+++ b/tests/test_scheduler_integration.py
@@ -324,11 +324,11 @@ def test_validate_schedule_invalid_node_sets() -> None:
     with pytest.raises(ValueError, match="Input nodes"):
         scheduler.validate_schedule()
 
-    # Reset and test measuring output node
+    # Reset and test measuring an output node without a measurement basis
     scheduler2 = Scheduler(graph, flow)
     scheduler2.prepare_time = {node1: 0}
-    scheduler2.measure_time = {node0: 1, node1: 1, node2: 2}  # node2 is output, shouldn't be measured
-    with pytest.raises(ValueError, match="Output nodes"):
+    scheduler2.measure_time = {node0: 1, node1: 1, node2: 2}  # node2 is an unmeasured output
+    with pytest.raises(ValueError, match="Unmeasured output nodes"):
         scheduler2.validate_schedule()
 
 

--- a/tests/test_stim_compiler.py
+++ b/tests/test_stim_compiler.py
@@ -710,7 +710,7 @@ def test_stim_compile_respects_manual_entangle_time() -> None:
 
     scheduler.manual_schedule(
         prepare_time={mid_node: 0, out_node: 0},
-        measure_time={in_node: 3, mid_node: 4},
+        measure_time={in_node: 3, mid_node: 4, out_node: 5},
         # Intentionally provide edges in reversed order to ensure they are still accepted.
         entangle_time={
             (mid_node, in_node): 2,

--- a/tests/test_stim_importer.py
+++ b/tests/test_stim_importer.py
@@ -10,6 +10,7 @@ import pytest
 from graphqomb.command import M
 from graphqomb.common import Axis, AxisMeasBasis, Sign
 from graphqomb.graphstate import odd_neighbors
+from graphqomb.pattern import is_runnable
 from graphqomb.qec.qeccode import YFoliation
 from graphqomb.simulator import PatternSimulator, SimulatorBackend
 from graphqomb.statevec import StateVector
@@ -207,6 +208,31 @@ def test_stim_text_to_pattern_imports_batched_feedback_pairs_by_parity() -> None
 
     assert frame.xflow[source] == {target}
     assert frame.zflow.get(source, set()) == set()
+
+
+def test_stim_text_to_pattern_schedules_direct_measurement_feedback_source_causally() -> None:
+    result = stim_text_to_pattern("M 0\nTICK\nCX rec[-1] 1\nTICK\nH 1")
+    pattern = result.pattern
+
+    is_runnable(pattern)
+    source = next(node for node, qubit in pattern.output_node_indices.items() if qubit == 0)
+    target = next(iter(pattern.pauli_frame.xflow[source]))
+    measured_order = [cmd.node for cmd in pattern if isinstance(cmd, M)]
+
+    assert measured_order.index(source) < measured_order.index(target)
+
+
+def test_stim_text_to_pattern_applies_direct_measurement_feedback_in_simulation() -> None:
+    rng = np.random.default_rng(7)
+    for _ in range(20):
+        result = stim_text_to_pattern("R 1\nM 0\nTICK\nCX rec[-1] 1\nTICK\nM 1")
+        simulator = PatternSimulator(result.pattern, SimulatorBackend.StateVector)
+        simulator.simulate(rng=rng)
+        source = next(node for node, qubit in result.pattern.output_node_indices.items() if qubit == 0)
+        target = next(node for node, qubit in result.pattern.output_node_indices.items() if qubit == 1)
+
+        # q1 is reset to |0>, then X^{m0} is applied, so M1 must equal M0.
+        assert simulator.results[source] == simulator.results[target]
 
 
 def test_stim_text_to_pattern_rejects_mixed_quantum_and_feedback_pairs() -> None:

--- a/tests/test_stim_importer.py
+++ b/tests/test_stim_importer.py
@@ -235,6 +235,21 @@ def test_stim_text_to_pattern_applies_direct_measurement_feedback_in_simulation(
         assert simulator.results[source] == simulator.results[target]
 
 
+def test_stim_text_to_pattern_splits_adjacent_feedback_and_unitary_operations() -> None:
+    stim_text = "RX 0\nR 1\nM 0\nTICK\nCX rec[-1] 1\nH 1\nTICK\nMX 1"
+
+    for seed in range(8):
+        result = stim_text_to_pattern(stim_text)
+        source = next(node for node, qubit in result.pattern.output_node_indices.items() if qubit == 0)
+        target = next(node for node, qubit in result.pattern.output_node_indices.items() if qubit == 1)
+        simulator = PatternSimulator(result.pattern, SimulatorBackend.StateVector)
+
+        simulator.simulate(rng=np.random.default_rng(seed))
+
+        # H maps X^{m0}|0> to the X-basis state with outcome m0.
+        assert simulator.results[target] == simulator.results[source]
+
+
 def test_stim_text_to_pattern_rejects_mixed_quantum_and_feedback_pairs() -> None:
     with pytest.raises(ValueError, match="exactly one measurement record"):
         stim_text_to_pattern("M 0\nTICK\nCX rec[-1] 1 2 3")

--- a/tests/test_stim_importer.py
+++ b/tests/test_stim_importer.py
@@ -15,7 +15,6 @@ from graphqomb.simulator import PatternSimulator, SimulatorBackend
 from graphqomb.statevec import StateVector
 from graphqomb.stim_compiler import stim_compile
 from graphqomb.stim_importer import stim_circuit_to_pattern, stim_file_to_pattern, stim_text_to_pattern
-from graphqomb.stim_parser import UnsupportedInstructionError
 
 stim = pytest.importorskip("stim")
 
@@ -99,14 +98,77 @@ def test_stim_text_to_pattern_does_not_advance_z_for_cancelled_single_qubit_bloc
     assert graph.coordinates[input_node] == (0.0, 0.0, 0.0)
 
 
-def test_stim_text_to_pattern_rejects_classically_controlled_clifford() -> None:
-    with pytest.raises(UnsupportedInstructionError) as exc_info:
-        stim_text_to_pattern("M 0\nTICK\nCX rec[-1] 1")
+@pytest.mark.parametrize(
+    ("instruction", "has_x_correction", "has_z_correction"),
+    [
+        ("CNOT rec[-1] 1", True, False),
+        ("CY rec[-1] 1", True, True),
+        ("CZ rec[-1] 1", False, True),
+        ("CZ 1 rec[-1]", False, True),
+        ("XCZ 1 rec[-1]", True, False),
+        ("YCZ 1 rec[-1]", True, True),
+    ],
+)
+def test_stim_text_to_pattern_imports_classically_controlled_pauli_corrections(
+    instruction: str,
+    has_x_correction: bool,
+    has_z_correction: bool,
+) -> None:
+    result = stim_text_to_pattern(f"M 0\nTICK\n{instruction}")
+    frame = result.pattern.pauli_frame
+    source = next(node for node, qubit in result.pattern.output_node_indices.items() if qubit == 0)
+    target = next(node for node, qubit in result.pattern.output_node_indices.items() if qubit == 1)
 
-    message = str(exc_info.value)
-    assert "Stim unitary TICK block 2" in message
-    assert "circuit, instruction 0" in message
-    assert "non-qubit target" in message
+    assert frame.xflow.get(source, set()) == ({target} if has_x_correction else set())
+    assert frame.zflow.get(source, set()) == ({target} if has_z_correction else set())
+
+
+def test_stim_text_to_pattern_adds_feedback_after_odd_neighbor_zflow_derivation() -> None:
+    result = stim_text_to_pattern(
+        """
+        MPP X0
+        DETECTOR rec[-1]
+        TICK
+        CNOT rec[-1] 1
+        TICK
+        H 1
+        """
+    )
+    frame = result.pattern.pauli_frame
+    source = next(iter(frame.parity_check_group[0]))
+    target = next(iter(frame.xflow[source]))
+    output = next(node for node, qubit in result.pattern.output_node_indices.items() if qubit == 1)
+
+    assert target != output
+    assert odd_neighbors({target}, frame.graphstate)
+    assert frame.zflow.get(source, set()) == set()
+
+
+def test_stim_text_to_pattern_imports_batched_feedback_pairs_by_parity() -> None:
+    result = stim_text_to_pattern(
+        """
+        MPP X0
+        DETECTOR rec[-1]
+        TICK
+        CX rec[-1] 1 rec[-1] 2 rec[-1] 2
+        """
+    )
+    frame = result.pattern.pauli_frame
+    source = next(iter(frame.parity_check_group[0]))
+    target = next(node for node, qubit in result.pattern.output_node_indices.items() if qubit == 1)
+
+    assert frame.xflow[source] == {target}
+    assert frame.zflow.get(source, set()) == set()
+
+
+def test_stim_text_to_pattern_rejects_mixed_quantum_and_feedback_pairs() -> None:
+    with pytest.raises(ValueError, match="exactly one measurement record"):
+        stim_text_to_pattern("M 0\nTICK\nCX rec[-1] 1 2 3")
+
+
+def test_stim_text_to_pattern_rejects_feedback_before_any_measurement_record() -> None:
+    with pytest.raises(ValueError, match="before the beginning of time"):
+        stim_text_to_pattern("CX rec[-1] 0")
 
 
 def test_stim_text_to_pattern_preserves_unitary_semantics_across_ticks() -> None:

--- a/tests/test_stim_importer.py
+++ b/tests/test_stim_importer.py
@@ -123,7 +123,7 @@ def test_stim_text_to_pattern_imports_classically_controlled_pauli_corrections(
     assert frame.zflow.get(source, set()) == ({target} if has_z_correction else set())
 
 
-def test_stim_text_to_pattern_adds_feedback_after_odd_neighbor_zflow_derivation() -> None:
+def test_stim_text_to_pattern_feedback_x_adds_deferred_z_on_future_neighbors() -> None:
     result = stim_text_to_pattern(
         """
         MPP X0
@@ -140,8 +140,56 @@ def test_stim_text_to_pattern_adds_feedback_after_odd_neighbor_zflow_derivation(
     output = next(node for node, qubit in result.pattern.output_node_indices.items() if qubit == 1)
 
     assert target != output
-    assert odd_neighbors({target}, frame.graphstate)
-    assert frame.zflow.get(source, set()) == set()
+    assert odd_neighbors({target}, frame.graphstate) == {output}
+    assert frame.zflow.get(source, set()) == {output}
+
+
+def test_stim_text_to_pattern_feedback_x_skips_z_on_past_neighbors() -> None:
+    result = stim_text_to_pattern(
+        """
+        MPP X0
+        DETECTOR rec[-1]
+        TICK
+        H 1
+        TICK
+        CNOT rec[-1] 1
+        TICK
+        H 1
+        """
+    )
+    frame = result.pattern.pauli_frame
+    source = next(iter(frame.parity_check_group[0]))
+    target = next(iter(frame.xflow[source]))
+    output = next(node for node, qubit in result.pattern.output_node_indices.items() if qubit == 1)
+    past_neighbors = frame.graphstate.neighbors(target) - {output}
+
+    assert past_neighbors
+    assert frame.zflow.get(source, set()) == {output}
+
+
+def test_stim_text_to_pattern_feedback_before_entanglement_keeps_detectors_deterministic() -> None:
+    result = stim_text_to_pattern(
+        """
+        R 1
+        RX 2
+        M 0
+        TICK
+        CX rec[-1] 1
+        TICK
+        CZ 1 2
+        TICK
+        MX 2
+        M 1
+        DETECTOR rec[-2] rec[-3]
+        DETECTOR rec[-1] rec[-3]
+        """
+    )
+    frame = result.pattern.pauli_frame
+
+    assert frame.detector_determinism() == [True, True]
+    exported = stim.Circuit(stim_compile(result.pattern))
+    # Raises if the exported circuit contains a non-deterministic detector.
+    exported.detector_error_model()
 
 
 def test_stim_text_to_pattern_imports_batched_feedback_pairs_by_parity() -> None:


### PR DESCRIPTION
## Summary

- import measurement-record-controlled Stim `CX`, `CY`, `CZ`, `XCZ`, and `YCZ` targets into pattern X/Z correction flows
- preserve each feedback instruction's circuit position while applying feedback only after graph-derived odd-neighbor Z-flow construction, so CNOT feedback X-flow does not generate Z-flow
- support batched feedback pairs with parity cancellation and reject mixed quantum/record-controlled pairs explicitly
- document the supported orientations and add the change to `CHANGELOG.md`

## Validation

- `uv run --extra stim pytest -q` — 820 passed, 1 skipped
- `uv run --extra stim ruff check ./graphqomb ./tests ./examples`
- `uv run --extra stim ruff format --check --diff`
- `uv run --extra stim pyright` — 0 errors, 0 warnings
- `uv run --extra stim mypy`
- `uv run --extra doc --extra stim sphinx-build -W docs/source docs/build`
- `git diff --check`