### PR TITLE
Update repository references after transfer

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: coverage
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,7 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Stim Compiler**: Detector and observable record indices now stay aligned when noise models emit heralded instructions that add measurement records
-- **Pattern Simulator**: Fixed adaptive measurement conjugation so non-Pauli measurements apply the missing angle sign flip from the Pauli frame during simulation ([#139](https://github.com/TeamGraphix/graphqomb/issues/139))
+- **Pattern Simulator**: Fixed adaptive measurement conjugation so non-Pauli measurements apply the missing angle sign flip from the Pauli frame during simulation ([#139](https://github.com/UTokyo-FT-MBQC/graphqomb/issues/139))
 - **Feedforward**: Fixed operator precedence bug in `dag_from_flow` where self-loops were only removed from `zflow` but not from `xflow`. The expression `xflow | zflow - {node}` was evaluated as `xflow | (zflow - {node})` due to `-` binding tighter than `|`. Corrected to `(xflow | zflow) - {node}`.
 
 ### Tests
@@ -185,7 +185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Integrated TICK command handling in PatternSimulator
   - Integrated TICK command processing in Stim compiler
 
-- **Edge Scheduler**: Automatic entanglement operation scheduling based on node preparation times ([#99](https://github.com/TeamGraphix/graphqomb/issues/99))
+- **Edge Scheduler**: Automatic entanglement operation scheduling based on node preparation times ([#99](https://github.com/UTokyo-FT-MBQC/graphqomb/issues/99))
   - Added `entangle_time` attribute to Scheduler for tracking entanglement operation timing
   - Added `auto_schedule_entanglement()` method to automatically schedule CZ gates when both nodes are prepared
   - Extended the `timeline` property to include entanglement operations
@@ -226,7 +226,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Graph State**: Bulk initialization methods for GraphState ([#120](https://github.com/TeamGraphix/graphqomb/issues/120))
+- **Graph State**: Bulk initialization methods for GraphState ([#120](https://github.com/UTokyo-FT-MBQC/graphqomb/issues/120))
   - Added `from_graph()` class method for direct graph-based initialization
   - Added `from_base_graph_state()` class method for initialization from base GraphState objects
   - Improved initialization flexibility for diverse use cases
@@ -260,7 +260,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Stim Compiler**: Pattern to Stim circuit compiler with detector and observable support for fault-tolerant quantum computing ([#67](https://github.com/TeamGraphix/graphqomb/issues/67))
+- **Stim Compiler**: Pattern to Stim circuit compiler with detector and observable support for fault-tolerant quantum computing ([#67](https://github.com/UTokyo-FT-MBQC/graphqomb/issues/67))
   - Compile MBQC patterns into Stim format for error correction analysis
   - Support for detectors, observables, and error models
   - Configurable depolarization noise after Clifford gates and measurements
@@ -281,16 +281,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Core Infrastructure**: Initial repository setup with project structure, build system, and CI/CD workflows ([#12](https://github.com/TeamGraphix/graphqomb/pull/12))
-- **Mathematical Foundations**: Euler angle computations for quantum operations ([#24](https://github.com/TeamGraphix/graphqomb/pull/24))
-- **Graph State**: Graph state representation and manipulation ([#34](https://github.com/TeamGraphix/graphqomb/pull/34))
-- **Pattern Module**: MBQC pattern data structures and operations ([#47](https://github.com/TeamGraphix/graphqomb/pull/47))
-- **Feedforward System**: Feedforward strategy design and implementation for adaptive measurements ([#40](https://github.com/TeamGraphix/graphqomb/pull/40))
-- **Command Module**: Measurement command definitions ([#43](https://github.com/TeamGraphix/graphqomb/pull/43))
-- **Qompiler**: Pattern compiler with Pauli frame implementation ([#55](https://github.com/TeamGraphix/graphqomb/pull/55))
-- **Scheduler**: Prepare time and measurement time scheduling for efficient execution ([#74](https://github.com/TeamGraphix/graphqomb/pull/74))
-- **Circuit Framework**: Quantum gate definitions and circuit representation ([#73](https://github.com/TeamGraphix/graphqomb/pull/73))
-- **Simulation Backend**: Statevector simulator backend for quantum state evolution ([#62](https://github.com/TeamGraphix/graphqomb/pull/62))
-- **Pattern and Circuit Simulation**: Complete simulation support for both patterns and circuits ([#78](https://github.com/TeamGraphix/graphqomb/pull/78))
-- **Visualization**: Basic visualizer for graph states and patterns ([#83](https://github.com/TeamGraphix/graphqomb/pull/83))
+- **Core Infrastructure**: Initial repository setup with project structure, build system, and CI/CD workflows ([#12](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/12))
+- **Mathematical Foundations**: Euler angle computations for quantum operations ([#24](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/24))
+- **Graph State**: Graph state representation and manipulation ([#34](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/34))
+- **Pattern Module**: MBQC pattern data structures and operations ([#47](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/47))
+- **Feedforward System**: Feedforward strategy design and implementation for adaptive measurements ([#40](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/40))
+- **Command Module**: Measurement command definitions ([#43](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/43))
+- **Qompiler**: Pattern compiler with Pauli frame implementation ([#55](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/55))
+- **Scheduler**: Prepare time and measurement time scheduling for efficient execution ([#74](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/74))
+- **Circuit Framework**: Quantum gate definitions and circuit representation ([#73](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/73))
+- **Simulation Backend**: Statevector simulator backend for quantum state evolution ([#62](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/62))
+- **Pattern and Circuit Simulation**: Complete simulation support for both patterns and circuits ([#78](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/78))
+- **Visualization**: Basic visualizer for graph states and patterns ([#83](https://github.com/UTokyo-FT-MBQC/graphqomb/pull/83))
 - **Documentation**: Comprehensive documentation on Read the Docs (https://graphqomb.readthedocs.io/)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # GraphQOMB
 
-![License](https://img.shields.io/github/license/TeamGraphix/graphqomb)
+![License](https://img.shields.io/github/license/UTokyo-FT-MBQC/graphqomb)
 [![PyPI version](https://badge.fury.io/py/graphqomb.svg)](https://pypi.org/project/graphqomb/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/graphqomb.svg)](https://pypi.org/project/graphqomb/)
 [![Documentation Status](https://readthedocs.org/projects/graphqomb/badge/?version=latest)](https://graphqomb.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/TeamGraphix/graphqomb/branch/master/graph/badge.svg)](https://codecov.io/gh/TeamGraphix/graphqomb)
-[![pytest](https://github.com/TeamGraphix/graphqomb/actions/workflows/pytest.yml/badge.svg)](https://github.com/TeamGraphix/graphqomb/actions/workflows/pytest.yml)
-[![typecheck](https://github.com/TeamGraphix/graphqomb/actions/workflows/typecheck.yml/badge.svg)](https://github.com/TeamGraphix/graphqomb/actions/workflows/typecheck.yml)
+[![codecov](https://codecov.io/gh/UTokyo-FT-MBQC/graphqomb/branch/main/graph/badge.svg)](https://codecov.io/gh/UTokyo-FT-MBQC/graphqomb)
+[![pytest](https://github.com/UTokyo-FT-MBQC/graphqomb/actions/workflows/pytest.yml/badge.svg)](https://github.com/UTokyo-FT-MBQC/graphqomb/actions/workflows/pytest.yml)
+[![typecheck](https://github.com/UTokyo-FT-MBQC/graphqomb/actions/workflows/typecheck.yml/badge.svg)](https://github.com/UTokyo-FT-MBQC/graphqomb/actions/workflows/typecheck.yml)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 **GraphQOMB** (Qompiler for Measurement-Based Quantum Computing, pronounced _graphcomb_) is a compiler framework for measurement-based quantum computation (MBQC). It keeps the resource-state structure, classical feedforward, and execution schedule as separate first-class objects, then lowers them to an executable measurement pattern with a Pauli frame.
@@ -59,7 +59,7 @@ uv add "graphqomb[stim]"
 ### From Source
 
 ```bash
-git clone https://github.com/TeamGraphix/graphqomb.git
+git clone https://github.com/UTokyo-FT-MBQC/graphqomb.git
 cd graphqomb
 uv sync
 ```
@@ -180,7 +180,7 @@ If you use GraphQOMB in your research, please cite:
   title = {GraphQOMB: A Modular Graph State Qompiler for Measurement-Based Quantum Computation},
   author = {Masato Fukushima, Sora Shiratani, Yuki Watanabe, and Daichi Sasaki},
   year = {2025},
-  url = {https://github.com/TeamGraphix/graphqomb}
+  url = {https://github.com/UTokyo-FT-MBQC/graphqomb}
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,11 @@ stim = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/TeamGraphix/graphqomb"
+Homepage = "https://github.com/UTokyo-FT-MBQC/graphqomb"
 Documentation = "https://graphqomb.readthedocs.io/"
-Repository = "https://github.com/TeamGraphix/graphqomb"
-Changelog = "https://github.com/TeamGraphix/graphqomb/blob/master/CHANGELOG.md"
-"Bug Tracker" = "https://github.com/TeamGraphix/graphqomb/issues"
+Repository = "https://github.com/UTokyo-FT-MBQC/graphqomb"
+Changelog = "https://github.com/UTokyo-FT-MBQC/graphqomb/blob/main/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/UTokyo-FT-MBQC/graphqomb/issues"
 
 [tool.setuptools.package-data]
 graphqomb = ["py.typed"]


### PR DESCRIPTION
## Summary

- update repository, issue, pull request, clone, citation, and badge URLs from `TeamGraphix/graphqomb` to `UTokyo-FT-MBQC/graphqomb`
- update the changelog URL and Codecov badge from `master` to `main`
- update the coverage workflow push target from `master` to `main`

## Why

The repository was transferred to the `UTokyo-FT-MBQC` organization and its default branch was changed to `main`. The existing metadata, documentation, badges, and coverage trigger still referenced the previous organization or branch.

## Impact

Package metadata and documentation now point to the canonical repository, and coverage runs on pushes to the current default branch. Other CI workflows remain pull-request or tag based and had no dependency on `master`.

## Validation

- pre-commit checks passed, including YAML validation
- `932 passed` with `uv run --no-sync pytest -q -s`
- confirmed no `master` references remain under `.github`
- confirmed the remote default branch is `main`