### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-27
+
 ### Changed (Breaking)
 
 - **Stim modules consolidated under `graphqomb.stim_glue`**: All Stim interoperability now lives in one subpackage, and the `graphqomb.qec` package is dissolved. `graphqomb.stim_compiler` moved to `graphqomb.stim_glue.compiler`, `graphqomb.stim_importer` to `graphqomb.stim_glue.importer`, `graphqomb.stim_parser` to `graphqomb.stim_glue.transpiler`, `graphqomb.stim_mpp_rewriter` to `graphqomb.stim_glue.mpp_rewriter`, and `graphqomb.qec.stim_mpp` to `graphqomb.stim_glue.mpp`; the shared parsing helpers formerly in `graphqomb.qec._stim` are now `graphqomb.stim_glue._parse`. The Stim-independent stabilizer-code builder `graphqomb.qec.qeccode` moved to the top-level `graphqomb.qeccode` module. `graphqomb.stim_glue` re-exports the public API (`stim_compile`, `stim_circuit_to_pattern`, `transpile`, `rewrite_to_mpp`, `stabilizer_code_from_stim_text`, and friends), so `from graphqomb.stim_glue import stim_compile` is the recommended import; importing `graphqomb.stim_glue` requires the optional `stim` dependency.

--- a/README.md
+++ b/README.md
@@ -113,10 +113,12 @@ If you already have a graph-state design and explicit feedforward maps, you can 
 - **Architecture overview**: https://graphqomb.readthedocs.io/en/latest/architecture.html
 - **Example gallery**: https://graphqomb.readthedocs.io/en/latest/gallery/index.html
 - **API reference**: https://graphqomb.readthedocs.io/en/latest/references.html
-- **QEC graph-state builder reference**: https://graphqomb.readthedocs.io/en/latest/qec.html
-- **Stim MPP import reference**: https://graphqomb.readthedocs.io/en/latest/stim_mpp.html
-- **Stim circuit import reference**: https://graphqomb.readthedocs.io/en/latest/stim_importer.html
-- **Stim compiler reference**: https://graphqomb.readthedocs.io/en/latest/stim_compiler.html
+- **QEC graph-state builder reference**: https://graphqomb.readthedocs.io/en/latest/qeccode.html
+- **Stim MPP import reference**: https://graphqomb.readthedocs.io/en/latest/stim_glue/mpp.html
+- **Stim MPP rewriter reference (experimental)**: https://graphqomb.readthedocs.io/en/latest/stim_glue/mpp_rewriter.html
+- **Stim Clifford transpiler reference**: https://graphqomb.readthedocs.io/en/latest/stim_glue/transpiler.html
+- **Stim circuit import reference**: https://graphqomb.readthedocs.io/en/latest/stim_glue/importer.html
+- **Stim compiler reference**: https://graphqomb.readthedocs.io/en/latest/stim_glue/compiler.html
 
 ## Current Scope
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graphqomb"
-version = "0.4.2"
+version = "0.5.0"
 description = "A modular Graph State qompiler for measurement-based quantum computing."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -704,7 +704,7 @@ wheels = [
 
 [[package]]
 name = "graphqomb"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary

Prepare the v0.5.0 release.

- Bump the package version to `0.5.0` (`pyproject.toml`, `uv.lock`) and close the `0.5.0` CHANGELOG section with today's date.
- Fix the README documentation links that still pointed at the pre-`stim_glue` page names: `qec.html` → `qeccode.html`, `stim_mpp.html` / `stim_importer.html` / `stim_compiler.html` → `stim_glue/{mpp,importer,compiler}.html`, and add links for the new `stim_glue/mpp_rewriter.html` and `stim_glue/transpiler.html` pages.

Highlights of this release (see CHANGELOG for the full list): Stim modules consolidated under `graphqomb.stim_glue` with the `graphqomb.qec` package dissolved (breaking), mid-circuit reset import, the experimental Stim MPP rewriter, classical feedback import, mixed TICK block import, qubit reuse after measurement, and first-class measured outputs.

## Test plan

Run locally against the repo venv (stim 1.16.0):

- [x] `pytest -m "not pyzx"` — 925 passed, 13 deselected
- [x] `ruff check ./graphqomb ./tests ./examples` and `ruff format --check` (pinned 0.15.22) — clean
- [x] `mypy` — no issues in 68 source files
- [x] `pyright` — 0 errors, 0 warnings
- [x] `sphinx-build -W docs/source` — builds with no warnings; every README link target exists in the built output

## Notes

Deliberately left out of this PR (reviewed but not addressed): the README feature list still advertises only the Stim export path, the CHANGELOG has no entry for the repository transfer to `UTokyo-FT-MBQC`, and the Stim test modules keep their pre-`stim_glue` filenames. No deprecation shims are provided for `graphqomb.stim_compiler` / `graphqomb.qec`; those imports fail outright, as documented in the breaking-change entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)