### PR TITLE
Add ty as a third type checker

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,8 +11,17 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        tool: [mypy, pyright]
+        include:
+          - tool: mypy
+            command: mypy
+          - tool: pyright
+            command: pyright
+          - tool: ty
+            command: ty check --output-format github
+
+    name: typecheck (${{ matrix.tool }})
 
     steps:
       - uses: actions/checkout@v7
@@ -28,4 +37,4 @@ jobs:
 
       - run: uv sync --locked --python 3.10 --extra dev --extra stim
 
-      - run: uv run --no-sync ${{ matrix.tool }}
+      - run: uv run --no-sync ${{ matrix.command }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ty Type Checking**: Added [ty](https://docs.astral.sh/ty/) as a third type checker alongside mypy and pyright, configured under `[tool.ty]` with every disabled-by-default rule promoted to `error`, and wired into the `Type Checking` workflow.
+- **Explicit Override Markers**: Every method overriding a base-class method now carries `@typing_extensions.override`.
+
+### Fixed
+
+- **Observable Index Parsing on Python 3.10 and 3.11**: `observable_index` used `int.is_integer()`, which requires Python 3.12, so an integer `OBSERVABLE_INCLUDE` argument raised `AttributeError`.
+
 ## [0.5.0] - 2026-07-27
 
 ### Changed (Breaking)

--- a/graphqomb/command.py
+++ b/graphqomb/command.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING
 
+import typing_extensions
+
 if TYPE_CHECKING:
     from graphqomb.common import MeasBasis
 
@@ -33,6 +35,7 @@ class N:
     node: int
     coordinate: tuple[float, ...] | None = None
 
+    @typing_extensions.override
     def __str__(self) -> str:
         if self.coordinate is not None:
             return f"N: node={self.node}, coord={self.coordinate}"
@@ -51,6 +54,7 @@ class E:
 
     nodes: tuple[int, int]
 
+    @typing_extensions.override
     def __str__(self) -> str:
         return f"E: nodes={self.nodes}"
 
@@ -70,6 +74,7 @@ class M:
     node: int
     meas_basis: MeasBasis
 
+    @typing_extensions.override
     def __str__(self) -> str:
         return f"M: node={self.node}, plane={self.meas_basis.plane}, angle={self.meas_basis.angle}"
 
@@ -82,6 +87,7 @@ class TICK:
     TICK commands can be executed in parallel within the same time slice.
     """
 
+    @typing_extensions.override
     def __str__(self) -> str:
         return "TICK"
 

--- a/graphqomb/gates.py
+++ b/graphqomb/gates.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeAlias
 
 import numpy as np
+import typing_extensions
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -109,6 +110,7 @@ class J(SingleGate):
     qubit: int
     angle: float
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the unit gates that make up the gate.
 
@@ -119,6 +121,7 @@ class J(SingleGate):
         """
         return [self]
 
+    @typing_extensions.override
     def matrix(self) -> NDArray[np.complex128]:
         r"""Get the matrix representation of the gate.
 
@@ -156,6 +159,7 @@ class CZ(TwoQubitGate):
 
     qubits: tuple[int, int]
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -166,7 +170,8 @@ class CZ(TwoQubitGate):
         """
         return [self]
 
-    def matrix(  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(
         self,
     ) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
@@ -202,6 +207,7 @@ class PhaseGadget(MultiGate):
     qubits: list[int]
     angle: float
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -212,6 +218,7 @@ class PhaseGadget(MultiGate):
         """
         return [self]
 
+    @typing_extensions.override
     def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
@@ -257,6 +264,7 @@ class Identity(SingleGate):
 
     qubit: int
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -267,7 +275,8 @@ class Identity(SingleGate):
         """
         return [J(self.qubit, 0), J(self.qubit, 0)]
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -298,6 +307,7 @@ class X(SingleGate):
 
     qubit: int
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -308,7 +318,8 @@ class X(SingleGate):
         """
         return [J(self.qubit, 0), J(self.qubit, math.pi)]
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -339,6 +350,7 @@ class Y(SingleGate):
 
     qubit: int
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -354,7 +366,8 @@ class Y(SingleGate):
             J(self.qubit, 0),
         ]
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -385,6 +398,7 @@ class Z(SingleGate):
 
     qubit: int
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -395,7 +409,8 @@ class Z(SingleGate):
         """
         return [J(self.qubit, math.pi), J(self.qubit, 0)]
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -426,6 +441,7 @@ class H(SingleGate):
 
     qubit: int
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -436,7 +452,8 @@ class H(SingleGate):
         """
         return [J(self.qubit, 0)]
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -468,6 +485,7 @@ class S(SingleGate):
 
     qubit: int
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -478,7 +496,8 @@ class S(SingleGate):
         """
         return [J(self.qubit, math.pi / 2), J(self.qubit, 0)]
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -509,6 +528,7 @@ class T(SingleGate):
 
     qubit: int
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -519,7 +539,8 @@ class T(SingleGate):
         """
         return [J(self.qubit, math.pi / 4), J(self.qubit, 0)]
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -550,6 +571,7 @@ class Tdg(SingleGate):
 
     qubit: int
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -560,7 +582,8 @@ class Tdg(SingleGate):
         """
         return [J(self.qubit, -math.pi / 4), J(self.qubit, 0)]
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -594,6 +617,7 @@ class Rx(SingleGate):
     qubit: int
     angle: float
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -607,6 +631,7 @@ class Rx(SingleGate):
             J(self.qubit, self.angle),
         ]
 
+    @typing_extensions.override
     def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
@@ -647,6 +672,7 @@ class Ry(SingleGate):
     qubit: int
     angle: float
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -662,6 +688,7 @@ class Ry(SingleGate):
             J(self.qubit, 0),
         ]
 
+    @typing_extensions.override
     def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
@@ -702,6 +729,7 @@ class Rz(SingleGate):
     qubit: int
     angle: float
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -712,6 +740,7 @@ class Rz(SingleGate):
         """
         return [J(self.qubit, self.angle), J(self.qubit, 0)]
 
+    @typing_extensions.override
     def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
@@ -755,6 +784,7 @@ class U3(SingleGate):
     angle2: float
     angle3: float
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -770,6 +800,7 @@ class U3(SingleGate):
             J(self.qubit, 0),
         ]
 
+    @typing_extensions.override
     def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
@@ -815,6 +846,7 @@ class CNOT(TwoQubitGate):
 
     qubits: tuple[int, int]
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -830,7 +862,8 @@ class CNOT(TwoQubitGate):
             J(target, 0),
         ]
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -866,6 +899,7 @@ class SWAP(TwoQubitGate):
 
     qubits: tuple[int, int]
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -885,7 +919,8 @@ class SWAP(TwoQubitGate):
             unit_gates.extend(macro_gate.unit_gates())
         return unit_gates
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -929,6 +964,7 @@ class CRz(TwoQubitGate):
     qubits: tuple[int, int]
     angle: float
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -949,6 +985,7 @@ class CRz(TwoQubitGate):
             unit_gates.extend(macro_gate.unit_gates())
         return unit_gates
 
+    @typing_extensions.override
     def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
@@ -993,6 +1030,7 @@ class CRx(TwoQubitGate):
     qubits: tuple[int, int]
     angle: float
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -1012,6 +1050,7 @@ class CRx(TwoQubitGate):
             unit_gates.extend(macro_gate.unit_gates())
         return unit_gates
 
+    @typing_extensions.override
     def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
@@ -1062,6 +1101,7 @@ class CU3(TwoQubitGate):
     angle2: float
     angle3: float
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -1084,6 +1124,7 @@ class CU3(TwoQubitGate):
             unit_gates.extend(macro_gate.unit_gates())
         return unit_gates
 
+    @typing_extensions.override
     def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
@@ -1139,6 +1180,7 @@ class Toffoli(MultiGate):
 
     qubits: list[int]
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -1170,7 +1212,8 @@ class Toffoli(MultiGate):
             unit_gates.extend(macro_gate.unit_gates())
         return unit_gates
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns
@@ -1219,6 +1262,7 @@ class CCZ(MultiGate):
 
     qubits: list[int]
 
+    @typing_extensions.override
     def unit_gates(self) -> list[UnitGate]:
         r"""Get the `unit_gates` that make up the gate.
 
@@ -1238,7 +1282,8 @@ class CCZ(MultiGate):
             unit_gates.extend(macro_gate.unit_gates())
         return unit_gates
 
-    def matrix(self) -> NDArray[np.complex128]:  # ruff:ignore[no-self-use]
+    @typing_extensions.override
+    def matrix(self) -> NDArray[np.complex128]:
         r"""Get the `matrix` representation of the gate.
 
         Returns

--- a/graphqomb/noise_model.py
+++ b/graphqomb/noise_model.py
@@ -87,6 +87,8 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import TYPE_CHECKING
 
+import typing_extensions
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
@@ -993,6 +995,7 @@ class DepolarizingNoiseModel(NoiseModel):
         self._p1 = _validate_probability("DepolarizingNoiseModel.p1", p1)
         self._p2 = self._p1 if p2 is None else _validate_probability("DepolarizingNoiseModel.p2", p2)
 
+    @typing_extensions.override
     def on_prepare(self, event: PrepareEvent) -> Sequence[NoiseOp]:
         r"""Add single-qubit depolarizing noise after preparation.
 
@@ -1005,6 +1008,7 @@ class DepolarizingNoiseModel(NoiseModel):
             return ()
         return (RawStimOp(f"DEPOLARIZE1({self._p1}) {event.node.id}"),)
 
+    @typing_extensions.override
     def on_entangle(self, event: EntangleEvent) -> Sequence[NoiseOp]:
         r"""Add two-qubit depolarizing noise after entanglement.
 
@@ -1040,6 +1044,7 @@ class MeasurementFlipNoiseModel(NoiseModel):
     def __init__(self, p: float) -> None:
         self._p = _validate_probability("MeasurementFlipNoiseModel.p", p)
 
+    @typing_extensions.override
     def on_measure(self, event: MeasureEvent) -> Sequence[NoiseOp]:
         r"""Add measurement flip error.
 

--- a/graphqomb/pattern.py
+++ b/graphqomb/pattern.py
@@ -15,6 +15,8 @@ import typing
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+import typing_extensions
+
 from graphqomb.command import TICK, Command, E, M, N
 from graphqomb.common import Axis
 
@@ -51,9 +53,11 @@ class Pattern(Sequence[Command]):
     input_coordinates: dict[int, tuple[float, ...]] = dataclasses.field(default_factory=dict[int, tuple[float, ...]])
     input_initialization_axes: dict[int, Axis] = dataclasses.field(default_factory=dict[int, Axis])
 
+    @typing_extensions.override
     def __len__(self) -> int:
         return len(self.commands)
 
+    @typing_extensions.override
     def __iter__(self) -> Iterator[Command]:
         return iter(self.commands)
 
@@ -61,6 +65,7 @@ class Pattern(Sequence[Command]):
     def __getitem__(self, index: int) -> Command: ...
     @typing.overload
     def __getitem__(self, index: slice) -> tuple[Command, ...]: ...
+    @typing_extensions.override
     def __getitem__(self, index: int | slice) -> Command | tuple[Command, ...]:
         return self.commands[index]
 

--- a/graphqomb/ptn_format.py
+++ b/graphqomb/ptn_format.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
+import typing_extensions
+
 from graphqomb.command import TICK, Command, E, M, N
 from graphqomb.common import (
     Axis,
@@ -534,59 +536,73 @@ class _LoadedGraphState(BaseGraphState):
             self._neighbors.setdefault(node2, set()).add(node1)
 
     @property
+    @typing_extensions.override
     def input_node_indices(self) -> dict[int, int]:
         return self._input_node_indices.copy()
 
     @property
+    @typing_extensions.override
     def input_initialization_axes(self) -> dict[int, Axis]:
         return self._input_initialization_axes.copy()
 
     @property
+    @typing_extensions.override
     def output_node_indices(self) -> dict[int, int]:
         return self._output_node_indices.copy()
 
     @property
+    @typing_extensions.override
     def nodes(self) -> set[int]:
         return set(self._nodes)
 
     @property
+    @typing_extensions.override
     def edges(self) -> set[tuple[int, int]]:
         return set(self._edges)
 
     @property
+    @typing_extensions.override
     def meas_bases(self) -> MappingProxyType[int, MeasBasis]:
         return MappingProxyType(self._meas_bases)
 
     @property
+    @typing_extensions.override
     def coordinates(self) -> dict[int, tuple[float, ...]]:
         return self._coordinates.copy()
 
+    @typing_extensions.override
     def add_node(self, node: int | None = None, *, coordinate: tuple[float, ...] | None = None) -> int:
         msg = "Loaded .ptn graph states are read-only"
         raise NotImplementedError(msg)
 
+    @typing_extensions.override
     def add_edge(self, node1: int, node2: int) -> None:
         msg = "Loaded .ptn graph states are read-only"
         raise NotImplementedError(msg)
 
+    @typing_extensions.override
     def register_input(self, node: int, q_index: int, *, init_axis: Axis = Axis.X) -> None:
         msg = "Loaded .ptn graph states are read-only"
         raise NotImplementedError(msg)
 
+    @typing_extensions.override
     def register_output(self, node: int, q_index: int) -> None:
         msg = "Loaded .ptn graph states are read-only"
         raise NotImplementedError(msg)
 
+    @typing_extensions.override
     def assign_meas_basis(self, node: int, meas_basis: MeasBasis) -> None:
         msg = "Loaded .ptn graph states are read-only"
         raise NotImplementedError(msg)
 
+    @typing_extensions.override
     def neighbors(self, node: int) -> set[int]:
         if node not in self._nodes:
             msg = f"Node does not exist node={node}"
             raise ValueError(msg)
         return self._neighbors.get(node, set()).copy()
 
+    @typing_extensions.override
     def check_canonical_form(self) -> None:
         for node in self._nodes - self._output_node_indices.keys():
             if node not in self._meas_bases:

--- a/graphqomb/stim_glue/_parse.py
+++ b/graphqomb/stim_glue/_parse.py
@@ -315,7 +315,8 @@ def observable_index(instruction: stim.CircuitInstruction) -> int:
         If the annotation does not have one integer argument.
     """
     args = instruction.gate_args_copy()
-    if len(args) != 1 or not args[0].is_integer():
+    # `int.is_integer` only exists from Python 3.12, so coerce to `float` first.
+    if len(args) != 1 or not float(args[0]).is_integer():
         msg = "OBSERVABLE_INCLUDE must have one integer observable index."
         raise ValueError(msg)
     return int(args[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
     "pytest-cov==7.1.0",
     "ruff==0.15.22",
     "scipy-stubs>=1.15.3.0",
+    "ty==0.0.64",
     "types-networkx==3.6.1.20260724",
 ]
 doc = [
@@ -184,6 +185,26 @@ directory = "htmlcov"
 strict = true
 ignore_missing_imports = true
 files = ["graphqomb", "tests", "examples"]
+
+[tool.ty.src]
+include = ["graphqomb", "tests", "examples"]
+
+[tool.ty.analysis]
+strict-literal-narrowing = true
+
+# ty enables nearly every rule by default, so this section only promotes the
+# handful that ship disabled or as warnings. See
+# https://docs.astral.sh/ty/reference/rules/ for the full list.
+[tool.ty.rules]
+blanket-ignore-comment = "error"
+division-by-zero = "error"
+missing-override-decorator = "error"
+missing-type-argument = "error"
+possibly-missing-attribute = "error"
+possibly-missing-import = "error"
+possibly-unresolved-reference = "error"
+unsupported-dynamic-base = "error"
+unused-ignore-comment = "error"
 
 [tool.pyright]
 include = ["graphqomb", "tests", "examples"]

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -7,6 +7,7 @@ import math
 
 import numpy as np
 import pytest
+import typing_extensions
 
 from graphqomb.circuit import BaseCircuit, Circuit, CircuitScheduleStrategy, MBQCCircuit, circuit2graph
 from graphqomb.common import Plane, PlannerMeasBasis
@@ -345,15 +346,18 @@ def test_circuit2graph_invalid_instruction() -> None:
     # Create a mock invalid circuit
     class MockCircuit(BaseCircuit):
         @property
+        @typing_extensions.override
         def num_qubits(self) -> int:
             return 1
 
+        @typing_extensions.override
         def instructions(self) -> list[Gate]:
             return [X(qubit=0)]
 
+        @typing_extensions.override
         def unit_instructions(self) -> list[UnitGate]:
             # Return a non-UnitGate object to trigger error
-            return [X(qubit=0)]  # type: ignore[list-item]
+            return [X(qubit=0)]  # type: ignore[list-item]  # ty: ignore[invalid-return-type]
 
     circuit = MockCircuit()
     with pytest.raises(TypeError, match="Invalid instruction"):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -9,11 +9,11 @@ from graphqomb.common import Axis, AxisMeasBasis, Plane, PlannerMeasBasis, Sign,
 
 def test_inverse_order_plane() -> None:
     with pytest.raises(AttributeError):
-        _ = PlannerMeasBasis(Plane.YX, 0)  # type: ignore[attr-defined]
+        _ = PlannerMeasBasis(Plane.YX, 0)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     with pytest.raises(AttributeError):
-        _ = PlannerMeasBasis(Plane.ZX, 0)  # type: ignore[attr-defined]
+        _ = PlannerMeasBasis(Plane.ZX, 0)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     with pytest.raises(AttributeError):
-        _ = PlannerMeasBasis(Plane.ZY, 0)  # type: ignore[attr-defined]
+        _ = PlannerMeasBasis(Plane.ZY, 0)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
 
 def test_is_clifford_angle() -> None:

--- a/tests/test_feedforward.py
+++ b/tests/test_feedforward.py
@@ -83,7 +83,7 @@ def test_dag_from_flow_invalid_type_raises() -> None:
     graphstate, node1, node2 = two_node_graph()
     invalid: dict[int, int | set[int]] = {node1: node2, node2: {node2}}  # mixed types
     with pytest.raises(TypeError):
-        dag_from_flow(graphstate, invalid)  # type: ignore[arg-type]
+        dag_from_flow(graphstate, invalid)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
 
 def test_dag_from_flow_cycle_detection() -> None:

--- a/tests/test_focus_flow.py
+++ b/tests/test_focus_flow.py
@@ -48,4 +48,4 @@ def test_is_focused_false_for_unfocused_flow(graphstate: GraphState) -> None:
 def test_focus_gflow_raises_typeerror(graphstate: GraphState) -> None:
     """If neither Flow nor GFlow, focus_gflow must raise TypeError."""
     with pytest.raises(TypeError):
-        focus_gflow({"bad": object()}, graphstate)  # type: ignore[arg-type]
+        focus_gflow({"bad": object()}, graphstate)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 
 import pytest
+import typing_extensions
 
 from graphqomb.common import Axis
 from graphqomb.noise_model import (
@@ -540,15 +541,19 @@ class _CustomNoiseModel(NoiseModel):
     def __init__(self, p: float) -> None:
         self.p = p
 
+    @typing_extensions.override
     def on_prepare(self, event: PrepareEvent) -> list[PauliChannel1]:
         return [PauliChannel1(px=self.p, py=0.0, pz=0.0, targets=[event.node.id])]
 
+    @typing_extensions.override
     def on_entangle(self, event: EntangleEvent) -> list[PauliChannel2]:
         return [PauliChannel2.from_mapping(probabilities={"ZZ": self.p}, targets=[(event.node0.id, event.node1.id)])]
 
+    @typing_extensions.override
     def on_measure(self, event: MeasureEvent) -> list[HeraldedPauliChannel1]:
         return [HeraldedPauliChannel1(pi=0.0, px=self.p, py=0.0, pz=0.0, targets=[event.node.id])]
 
+    @typing_extensions.override
     def on_idle(self, event: IdleEvent) -> list[PauliChannel1]:
         p = self.p * event.duration
         targets = [n.id for n in event.nodes]

--- a/tests/test_qeccode.py
+++ b/tests/test_qeccode.py
@@ -460,4 +460,4 @@ def test_build_graph_state_rejects_non_integer_z_base() -> None:
     code = StabilizerCode(_matrix([[1, 0]]))
 
     with pytest.raises(TypeError, match="z_base must be an integer"):
-        build_graph_state(code, z_base=0.5)  # type: ignore[arg-type]
+        build_graph_state(code, z_base=0.5)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]

--- a/tests/test_stim_compiler.py
+++ b/tests/test_stim_compiler.py
@@ -6,6 +6,7 @@ import math
 from typing import TYPE_CHECKING
 
 import pytest
+import typing_extensions
 
 from graphqomb.command import TICK, E, M, N
 from graphqomb.common import Axis, AxisMeasBasis, Plane, PlannerMeasBasis, Sign
@@ -281,7 +282,7 @@ def test_stim_compile_removed_legacy_noise_parameters() -> None:
     pattern, _, _ = create_simple_pattern_x_measurement()
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'p_before_meas_flip'"):
-        stim_compile(pattern, p_before_meas_flip=0.01)  # type: ignore[call-arg]
+        stim_compile(pattern, p_before_meas_flip=0.01)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
 
 
 def test_stim_compile_with_detectors() -> None:
@@ -318,6 +319,7 @@ def test_stim_compile_with_detectors() -> None:
 class _HeraldedNoise(NoiseModel):
     """Test noise model that adds heralded Pauli channel on measurements."""
 
+    @typing_extensions.override
     def on_measure(self, event: MeasureEvent) -> list[HeraldedPauliChannel1]:
         return [HeraldedPauliChannel1(0.0, 0.0, 0.0, 0.1, targets=[event.node.id])]
 
@@ -325,6 +327,7 @@ class _HeraldedNoise(NoiseModel):
 class _MismatchedMeasurementFlipNoise(NoiseModel):
     """Test noise model with intentionally mismatched MeasurementFlip target."""
 
+    @typing_extensions.override
     def on_measure(self, event: MeasureEvent) -> list[MeasurementFlip]:
         return [MeasurementFlip(p=0.1, target=event.node.id + 999)]
 
@@ -332,6 +335,7 @@ class _MismatchedMeasurementFlipNoise(NoiseModel):
 class _PrepareMeasurementFlipNoise(NoiseModel):
     """Test noise model with invalid MeasurementFlip on prepare."""
 
+    @typing_extensions.override
     def on_prepare(self, event: PrepareEvent) -> list[MeasurementFlip]:
         return [MeasurementFlip(p=0.1, target=event.node.id)]
 
@@ -339,6 +343,7 @@ class _PrepareMeasurementFlipNoise(NoiseModel):
 class _EntangleMeasurementFlipNoise(NoiseModel):
     """Test noise model with invalid MeasurementFlip on entangle."""
 
+    @typing_extensions.override
     def on_entangle(self, event: EntangleEvent) -> list[MeasurementFlip]:
         return [MeasurementFlip(p=0.1, target=event.node0.id)]
 
@@ -346,6 +351,7 @@ class _EntangleMeasurementFlipNoise(NoiseModel):
 class _IdleMeasurementFlipNoise(NoiseModel):
     """Test noise model with invalid MeasurementFlip on idle."""
 
+    @typing_extensions.override
     def on_idle(self, event: IdleEvent) -> list[MeasurementFlip]:
         return [MeasurementFlip(p=0.1, target=event.nodes[0].id)]
 

--- a/uv.lock
+++ b/uv.lock
@@ -730,6 +730,7 @@ dev = [
     { name = "scipy-stubs", version = "1.15.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy-stubs", version = "1.17.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy-stubs", version = "1.18.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "ty" },
     { name = "types-networkx" },
 ]
 doc = [
@@ -767,6 +768,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'doc'", specifier = ">=8.1.3" },
     { name = "sphinx-gallery", marker = "extra == 'doc'", specifier = ">=0.17.0" },
     { name = "stim", marker = "extra == 'stim'", specifier = ">=1.15" },
+    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.64" },
     { name = "types-networkx", marker = "extra == 'dev'", specifier = "==3.6.1.20260724" },
     { name = "typing-extensions" },
 ]
@@ -2933,6 +2935,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.64"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/aa/14c9965d3b173105692473897cc89c34cd91241368b2044e43167e1c17ff/ty-0.0.64.tar.gz", hash = "sha256:d12ddbb05f15158bb518af619378b385486450def95fb06f8ab98037febe9f2c", size = 6350966, upload-time = "2026-07-27T18:32:45.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/4c/c54937e4ff3fa7b34a99ea3387ec766bf0ad98dc8df8d792e89b388e658e/ty-0.0.64-py3-none-linux_armv6l.whl", hash = "sha256:3830a6675ab43635ced1c4c557f380ac4a49e9414e03975e4e4e8db644c64944", size = 12118357, upload-time = "2026-07-27T18:32:08.702Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/a839ee2bc78e943d079e6abe199a97b4eeffb7e5c9a57326d69de452186a/ty-0.0.64-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3ff07d7bc32a2135f58afe57393789a32ea2fed1a66216129a8e535e76043903", size = 11790882, upload-time = "2026-07-27T18:32:10.997Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/de/19f14357888a7198438926303753cf749428e3d62e8980ff1e9a72a78402/ty-0.0.64-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4f6d1c7f897cca05d12bacbf1435150d5ffa496099515aa6ed303c8b29e1d0bb", size = 11317394, upload-time = "2026-07-27T18:32:13.162Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2f/f54462300535ab99b551eda733177be2eef5dbc2997d3fdb357c4ddd760a/ty-0.0.64-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:138d6c37ad4bf8583aa7a9b29d90954151d7856f9910a03eae3eb34b34c57215", size = 11863042, upload-time = "2026-07-27T18:32:15.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/95/dbecf745520ebe8bd7b02fc55eee6441c9be312ebf6addce605eb52740dd/ty-0.0.64-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1ed9719d1b7b66fb8efe073d860208a44c40af1f6cd5c2364aa9b323a1e579b4", size = 11910730, upload-time = "2026-07-27T18:32:17.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/26/12cfd40028e51ceed7b3cb645281c61c02eb64ff9fb0c09231d65c30ff25/ty-0.0.64-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d68b23e5169e2137b5f1de7169ab0cebecab6c8eda374c34c1f6394308f58242", size = 12631936, upload-time = "2026-07-27T18:32:19.533Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d0/65ffc2b0a686347193c6f98e9421a7fc2a96fc3cd0b1001cf7cf284baff9/ty-0.0.64-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f41cb07d89d32626fcaf3ed4d262778fcb28b2628b6ed1e172cd7b18820668d8", size = 13171049, upload-time = "2026-07-27T18:32:22.026Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a4/975a5961842dcd6fa60f0770a102c0bba7509da909ab652919bfcdcd4fc7/ty-0.0.64-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5f24e1504ab9e212f92356b82fe088fdeb3a39f9a2f4ff25e505d2e1d0db9056", size = 12826438, upload-time = "2026-07-27T18:32:24.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ef/dfb9b7f9bcc032d3b540b0d1f55f532a336e2fb41b1bd539c05ae81a151a/ty-0.0.64-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86db830cb914bb33bb8247b66ccea58de4496c2391bd42658aba744b439f3290", size = 12440880, upload-time = "2026-07-27T18:32:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d0/bedac20505e8a8f5501ad73d7d15d8e421a563fef59993909a23036929a4/ty-0.0.64-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:652ee3d6d03bea76cd2fe8949c78bb5970394ebd7c5fd270e9518c0dee1b931d", size = 12782439, upload-time = "2026-07-27T18:32:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d5/795733f13ceff1378f08b3de0c49d0f518df220ed856b0dfac869f3b7c81/ty-0.0.64-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4838768295774a86e95f9ec5633e739d016adbbb69dcbdc62f3549578a11f624", size = 11814821, upload-time = "2026-07-27T18:32:30.632Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3e/9d99cd1e1831003434f508ed9f258a56543194afc3bbe051eba2545fa676/ty-0.0.64-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5a3d700669868599edf39ce5125196682f15a8880cc8c669bc2a83b99984d99b", size = 11928678, upload-time = "2026-07-27T18:32:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3d/448f49a3503fb119a34348a5714bb92001f252fadbbb12d645f2e744b557/ty-0.0.64-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b161f0a82a8e2f2432db3bf7702b4d3924fa9486ba0014f6710a160fc157df0d", size = 12202249, upload-time = "2026-07-27T18:32:34.905Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9b/75768e562cec990d189dc05807ae72890b20ffbd1e1f43597bb98db63c60/ty-0.0.64-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:39b9dd42908df47c2dc57dda87e656fab97097ffd2618474bbdea986af0d6a9d", size = 12548817, upload-time = "2026-07-27T18:32:36.995Z" },
+    { url = "https://files.pythonhosted.org/packages/34/89/44cc276ea6ca0245495014758ffeadde1798fb0b5840c9cf36d8d2ed3250/ty-0.0.64-py3-none-win32.whl", hash = "sha256:d0676ab0e0935795e5843baa28dd5e366dc343d7c0945a996df9eab8e0644885", size = 11545474, upload-time = "2026-07-27T18:32:39.389Z" },
+    { url = "https://files.pythonhosted.org/packages/01/7e/d1c8a871a38d17c8f168b9a6975f6247f7660f8334e517656a5e4b4a4858/ty-0.0.64-py3-none-win_amd64.whl", hash = "sha256:dcb9bd31f54097e362b776c26ab4564d4564cdd1355cb883481167a26c03cc3f", size = 12542987, upload-time = "2026-07-27T18:32:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/6d18640d0204cacd69abbaca95ad6a34c6d7e9169e9051d0117b17b827ec/ty-0.0.64-py3-none-win_arm64.whl", hash = "sha256:82cc34c1ad9a8feb6059aef193bebcecc656e548f6fab3d518bcd8b57d198d39", size = 11899263, upload-time = "2026-07-27T18:32:43.366Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Introduces [ty](https://docs.astral.sh/ty/) (astral-sh) alongside mypy and pyright. `ty==0.0.64` is pinned in the `dev` extra, `[tool.ty]` configures it over `graphqomb`, `tests`, and `examples`, and the `Type Checking` workflow gains a `ty` matrix entry (the matrix moved to `include` form because `ty` needs the `check` subcommand).

ty enables nearly every rule by default and is already stricter than mypy `--strict` in several respects — unannotated function bodies are always checked, and there is no `check_untyped_defs` equivalent to turn off. The configuration therefore only promotes the handful of rules that ship disabled or as warnings to `error`, plus `strict-literal-narrowing`. Annotation-coverage rules have no ty equivalent by design; upstream defers those to ruff's `ANN`/`PYI`, which `select = ["ALL"]` already covers.

The repository passes at that setting, and also passes `ty check --error=all`, so `[tool.ty.rules]` could be collapsed to `all = "error"` later if that is preferred.

## Code changes needed to reach a clean run

- **`@typing_extensions.override` on 80 methods** — `missing-override-decorator` flagged every method overriding a base method without the decorator (`gates.py` 44, `ptn_format.py` 14, `command.py` 4, `noise_model.py` 3, `pattern.py` 3, tests 12). This matches the convention already used in `circuit.py`, `common.py`, and `statevec.py`. Side effect: ruff's `no-self-use` skips `@override` methods, so 13 now-unused `# ruff:ignore[no-self-use]` suppressions in `gates.py` were removed.
- **Latent bug fix** — `observable_index` called `int.is_integer()`, which only exists from Python 3.12. With `requires-python = ">=3.10"`, an `OBSERVABLE_INCLUDE` argument that Stim returns as an `int` raised `AttributeError` on 3.10 and 3.11.
- **Suppression comments** — ty ignores codes without a `ty:` prefix, and mypy strict reports a `ty:`-prefixed code inside its own `type: ignore[...]` as an unused ignore. The six mypy-suppressed lines in the test suite (all intentional negative tests) carry a separate `# ty: ignore[<rule>]` comment on the same line.

## Verification

All run locally on Python 3.10:

| Check | Result |
| --- | --- |
| `ty check` | All checks passed |
| `ty check --error=all` | All checks passed |
| `mypy` | no issues found in 68 source files |
| `pyright` | 0 errors, 0 warnings |
| `ruff check` / `ruff format --check` | clean |
| `pytest` | 925 passed, 1 skipped |
| `uv lock --check` | up to date |

## Note

ty is at 0.0.64 and pre-1.0 (upstream targets 1.0 during 2026), so the version is pinned exactly like the other dev tools and 0.0.x bumps should be treated as potentially breaking. Keeping mypy and pyright is deliberate: several of their checks are not yet implemented in ty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)