### PR TITLE
Release GraphQOMB 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-08-04
+
 ### Added
 
 - **MPP Rewriter Segment Fallback**: `rewrite_to_mpp(..., fallback="segment")` keeps unsupported segments gate-level while rewriting the rest to `MPP`; the default remains `"circuit"`. Measurement post-state reuse, record feedback, and dependent producer segments fall back together, while noise remains rejected. `MppRewriteResult.fallback_segments` reports retained segments, and deterministic-minus feedback records stay signed measurements instead of unsupported `MPAD 1`. On Gidney's logical-Y circuits, node count falls from 9951 directly imported to 6237 at d=9, r=9 (8217 with safe TICK merging alone).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graphqomb"
-version = "0.5.1"
+version = "0.5.2"
 description = "A modular Graph State qompiler for measurement-based quantum computing."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -704,7 +704,7 @@ wheels = [
 
 [[package]]
 name = "graphqomb"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary

- Cut the existing unreleased changelog entries as GraphQOMB 0.5.2, dated 2026-08-04.
- Bump the project and lockfile package metadata from 0.5.1 to 0.5.2.

## Impact

This prepares the 0.5.2 release containing safe TICK merging, per-segment MPP rewrite fallback, and the detector-determinism fix merged since 0.5.1. The release PR itself changes only release metadata.

## Validation

- `uv lock --check`
- Installed package metadata reports `graphqomb==0.5.2`
- `uv run --extra stim pytest -q` — 1073 passed
- `uv run --with build==1.5.0 python -m build --installer uv` — sdist and wheel built successfully
- Built sdist and wheel metadata report `graphqomb==0.5.2` and Python `>=3.10,<3.15`
- `git diff --check origin/main...HEAD`
