### PR TITLE
Add scheduler passthrough to the Stim importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Stim Import Scheduler Passthrough**: `stim_circuit_to_pattern()`, `stim_text_to_pattern()`, and `stim_file_to_pattern()` accept `schedule_config` and `schedule_timeout`. When a `ScheduleConfig` is given, the importer builds a `Scheduler` from the imported graph and flows, solves it with that configuration (e.g. `ScheduleConfig(Strategy.MINIMIZE_TIME, use_greedy=False)` for the CP-SAT solver), and compiles the pattern with the solved schedule; a `ValueError` is raised when no schedule is found. When omitted, `qompile` keeps scheduling with its default greedy strategy. This restores external control over the emitted command order — e.g. entangling-order studies that reorder `E` commands within contiguous runs can request the CP-SAT schedule instead of pinning an old library version.
+
 ### Changed (Breaking)
 
 - **Scheduler subpackage**: `graphqomb.scheduler`, `graphqomb.greedy_scheduler`, and `graphqomb.schedule_solver` moved to `graphqomb.scheduler.core`, `graphqomb.scheduler.greedy`, and `graphqomb.scheduler.solver`. The `graphqomb.scheduler` package re-exports the public API, so import everything scheduling-related from `graphqomb.scheduler`.

--- a/graphqomb/stim_glue/importer.py
+++ b/graphqomb/stim_glue/importer.py
@@ -264,10 +264,11 @@ def stim_circuit_to_pattern(  # ruff:ignore[too-many-locals, too-many-arguments]
     """Import a supported Stim circuit into a GraphQOMB pattern.
 
     ``schedule_config`` controls how the imported pattern is scheduled: when
-    given, a `graphqomb.scheduler.Scheduler` is built from the imported graph
-    and flows, solved with that configuration (``schedule_timeout`` bounds the
-    CP-SAT solve time in seconds), and passed to `graphqomb.qompiler.qompile`;
-    when `None`, ``qompile`` schedules with its default greedy strategy.
+    given, a `graphqomb.scheduler.core.Scheduler` is built from the imported
+    graph and flows, solved with that configuration (``schedule_timeout``
+    bounds the CP-SAT solve time in seconds), and passed to
+    `graphqomb.qompiler.qompile`; when `None`, ``qompile`` schedules with its
+    default greedy strategy.
 
     The importer supports initial Pauli resets, Clifford unitary blocks, and
     Pauli measurement blocks. Stim ``R``, ``RX``, and ``RY`` instructions are

--- a/graphqomb/stim_glue/importer.py
+++ b/graphqomb/stim_glue/importer.py
@@ -16,6 +16,7 @@ from graphqomb.gates import CZ, J
 from graphqomb.graphstate import GraphState, compose, odd_neighbors
 from graphqomb.qeccode import StabilizerGraphStateBuildResult, YFoliation, build_graph_state
 from graphqomb.qompiler import qompile
+from graphqomb.scheduler import Scheduler
 from graphqomb.stim_glue._parse import (
     DIRECT_MEASUREMENT_AXES,
     MEASURE_RESET_AXES,
@@ -39,6 +40,7 @@ if TYPE_CHECKING:
     from collections.abc import Set as AbstractSet
 
     from graphqomb.pattern import Pattern
+    from graphqomb.scheduler import ScheduleConfig
     from graphqomb.stim_glue._parse import RecordAnnotations
 
 
@@ -183,19 +185,22 @@ class _FragmentBuildResult:
     qubit_to_stim: dict[int, int]
 
 
-def stim_file_to_pattern(
+def stim_file_to_pattern(  # ruff:ignore[too-many-arguments]
     path: str | Path,
     *,
     coord_dims: int = 2,
     schedule_strategy: CircuitScheduleStrategy = CircuitScheduleStrategy.PARALLEL,
     y_foliation: YFoliation = YFoliation.TYPE_I,
     merge_safe_ticks: bool = False,
+    schedule_config: ScheduleConfig | None = None,
+    schedule_timeout: int = 60,
 ) -> StimImportResult:
     """Import a supported Stim file into a GraphQOMB pattern.
 
     When ``merge_safe_ticks`` is true, TICK boundaries whose removal cannot
     change the imported semantics are dropped before import; see
-    `stim_circuit_to_pattern`.
+    `stim_circuit_to_pattern`. ``schedule_config`` and ``schedule_timeout``
+    select the pattern-level scheduler; see `stim_circuit_to_pattern`.
 
     Returns
     -------
@@ -208,22 +213,27 @@ def stim_file_to_pattern(
         schedule_strategy=schedule_strategy,
         y_foliation=y_foliation,
         merge_safe_ticks=merge_safe_ticks,
+        schedule_config=schedule_config,
+        schedule_timeout=schedule_timeout,
     )
 
 
-def stim_text_to_pattern(
+def stim_text_to_pattern(  # ruff:ignore[too-many-arguments]
     text: str,
     *,
     coord_dims: int = 2,
     schedule_strategy: CircuitScheduleStrategy = CircuitScheduleStrategy.PARALLEL,
     y_foliation: YFoliation = YFoliation.TYPE_I,
     merge_safe_ticks: bool = False,
+    schedule_config: ScheduleConfig | None = None,
+    schedule_timeout: int = 60,
 ) -> StimImportResult:
     """Import supported Stim text into a GraphQOMB pattern.
 
     When ``merge_safe_ticks`` is true, TICK boundaries whose removal cannot
     change the imported semantics are dropped before import; see
-    `stim_circuit_to_pattern`.
+    `stim_circuit_to_pattern`. ``schedule_config`` and ``schedule_timeout``
+    select the pattern-level scheduler; see `stim_circuit_to_pattern`.
 
     Returns
     -------
@@ -236,18 +246,28 @@ def stim_text_to_pattern(
         schedule_strategy=schedule_strategy,
         y_foliation=y_foliation,
         merge_safe_ticks=merge_safe_ticks,
+        schedule_config=schedule_config,
+        schedule_timeout=schedule_timeout,
     )
 
 
-def stim_circuit_to_pattern(  # ruff:ignore[too-many-locals]
+def stim_circuit_to_pattern(  # ruff:ignore[too-many-locals, too-many-arguments]
     circuit: stim.Circuit,
     *,
     coord_dims: int = 2,
     schedule_strategy: CircuitScheduleStrategy = CircuitScheduleStrategy.PARALLEL,
     y_foliation: YFoliation = YFoliation.TYPE_I,
     merge_safe_ticks: bool = False,
+    schedule_config: ScheduleConfig | None = None,
+    schedule_timeout: int = 60,
 ) -> StimImportResult:
     """Import a supported Stim circuit into a GraphQOMB pattern.
+
+    ``schedule_config`` controls how the imported pattern is scheduled: when
+    given, a `graphqomb.scheduler.Scheduler` is built from the imported graph
+    and flows, solved with that configuration (``schedule_timeout`` bounds the
+    CP-SAT solve time in seconds), and passed to `graphqomb.qompiler.qompile`;
+    when `None`, ``qompile`` schedules with its default greedy strategy.
 
     The importer supports initial Pauli resets, Clifford unitary blocks, and
     Pauli measurement blocks. Stim ``R``, ``RX``, and ``RY`` instructions are
@@ -331,7 +351,8 @@ def stim_circuit_to_pattern(  # ruff:ignore[too-many-locals]
     Raises
     ------
     ValueError
-        If the circuit uses unsupported instructions or invalid coordinates.
+        If the circuit uses unsupported instructions or invalid coordinates,
+        or if ``schedule_config`` is given and no schedule is found.
     """
     if coord_dims not in {2, 3}:
         msg = "coord_dims must be 2 or 3."
@@ -378,12 +399,21 @@ def stim_circuit_to_pattern(  # ruff:ignore[too-many-locals]
         record_nodes=fragment.record_nodes,
         zero_record_indices=idealized.zero_record_indices,
     )
+    xflow, zflow = _flows_with_feedback(fragment, zero_record_indices=idealized.zero_record_indices)
+    scheduler: Scheduler | None = None
+    if schedule_config is not None:
+        scheduler = Scheduler(fragment.graph, xflow, zflow)
+        if not scheduler.solve_schedule(schedule_config, timeout=schedule_timeout):
+            msg = "Scheduling the imported pattern failed with the requested schedule_config."
+            raise ValueError(msg)
     pattern = qompile(
         fragment.graph,
-        *_flows_with_feedback(fragment, zero_record_indices=idealized.zero_record_indices),
+        xflow,
+        zflow,
         parity_check_group=parity_check_groups,
         logical_observables=logical_observables,
         parity_check_tags=parity_check_tags,
+        scheduler=scheduler,
     )
     return StimImportResult(
         pattern=pattern,

--- a/tests/test_stim_importer.py
+++ b/tests/test_stim_importer.py
@@ -10,12 +10,13 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
-from graphqomb.command import M
+from graphqomb.command import E, M
 from graphqomb.common import Axis, AxisMeasBasis, Sign
 from graphqomb.graphstate import odd_neighbors
 from graphqomb.pattern import is_runnable
 from graphqomb.ptn_format import dumps as ptn_dumps
 from graphqomb.qeccode import YFoliation
+from graphqomb.scheduler import ScheduleConfig, Strategy
 from graphqomb.simulator import PatternSimulator, SimulatorBackend
 from graphqomb.statevec import StateVector
 from graphqomb.stim_glue.compiler import stim_compile
@@ -1847,3 +1848,37 @@ def test_stim_import_export_round_trip_preserves_detector_tags() -> None:
 
     detector_tags = [instruction.tag for instruction in compiled if instruction.name == "DETECTOR"]
     assert detector_tags == ["type=flag", ""]
+
+
+def test_stim_text_to_pattern_schedule_config_solves_with_cpsat() -> None:
+    text = """
+        RX 0
+        R 1
+        TICK
+        CZ 0 1
+        TICK
+        M 1
+        DETECTOR rec[-1]
+        TICK
+        MX 0
+        """
+    default = stim_text_to_pattern(text)
+    solved = stim_text_to_pattern(
+        text,
+        schedule_config=ScheduleConfig(Strategy.MINIMIZE_TIME, use_greedy=False),
+    )
+
+    is_runnable(solved.pattern)
+    default_edges = {frozenset(command.nodes) for command in default.pattern.commands if isinstance(command, E)}
+    solved_edges = {frozenset(command.nodes) for command in solved.pattern.commands if isinstance(command, E)}
+    assert solved_edges == default_edges
+    compiled = stim.Circuit(stim_compile(solved.pattern))
+    assert not compiled.compile_detector_sampler().sample(shots=32).any()
+
+
+def test_stim_text_to_pattern_schedule_config_infeasible_raises() -> None:
+    with pytest.raises(ValueError, match="schedule_config"):
+        stim_text_to_pattern(
+            "RX 0\nR 1\nTICK\nCZ 0 1\nTICK\nM 1\nTICK\nMX 0",
+            schedule_config=ScheduleConfig(Strategy.MINIMIZE_TIME, max_qubit_count=1, use_greedy=False),
+        )


### PR DESCRIPTION
**Context (if applicable):**

Since greedy scheduling became the `qompile` default (#264), the Stim importer offers no way to choose the schedule of the compiled pattern: `stim_circuit_to_pattern` calls `qompile` without a scheduler, so the emitted command order is whatever the greedy heuristic produces. Downstream entangling-order studies that impose an explicit `E`-command order (by permuting `E` commands within contiguous runs) relied on the previous CP-SAT default, which emitted each ancilla's entangles in one contiguous run; with the greedy default those runs are interleaved with measurements and the reordering machinery rejects the pattern. Until now the only workaround was pinning the library at v0.5.2.

**Description of the change:**

- `stim_circuit_to_pattern()`, `stim_text_to_pattern()`, and `stim_file_to_pattern()` accept `schedule_config: ScheduleConfig | None = None` and `schedule_timeout: int = 60`.
- When `schedule_config` is given, the importer builds a `Scheduler` from the imported graph and flows, solves it with that configuration (`schedule_timeout` bounds the CP-SAT solve time), and passes it to `qompile`; `ValueError` is raised when no schedule is found.
- When omitted, behavior is unchanged: `qompile` schedules with its default greedy strategy.
- Tests: a CP-SAT import solves, stays runnable, keeps the entangle-edge set, and samples silent detectors; an infeasible configuration (`max_qubit_count=1` against a CZ) raises.
- Regression check on the motivating workload (triangle-code memory import, external repo): importing with `ScheduleConfig(Strategy.MINIMIZE_TIME, use_greedy=False)` on current main reproduces the v0.5.2 compiled circuits byte-for-byte at d=3 and d=5 for all 6 (basis, foliation) combinations.

Checklist: `pytest tests/test_stim_importer.py` (232 passed), `ruff check`/`format --check` clean (ruff 0.15.22), `mypy graphqomb/stim_glue/importer.py` clean, CHANGELOG updated under [Unreleased].

**Related issue:**

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)