### PR TITLE
Align docstring tag and backquote style with the original conventions

### DIFF
--- a/graphqomb/command.py
+++ b/graphqomb/command.py
@@ -67,7 +67,7 @@ class M:
     ----------
     node : `int`
         The node index to be measured.
-    meas_basis : MeasBasis
+    meas_basis : `MeasBasis`
         The measurement basis.
     """
 

--- a/graphqomb/common.py
+++ b/graphqomb/common.py
@@ -75,7 +75,7 @@ class Initialization:
     Raises
     ------
     TypeError
-        If ``axis`` is not an `Axis` value or ``tag`` is not a `str`.
+        If axis is not an `Axis` value or tag is not a `str`.
     """
 
     axis: Axis = Axis.X

--- a/graphqomb/graphstate.py
+++ b/graphqomb/graphstate.py
@@ -559,7 +559,7 @@ class GraphState(BaseGraphState):
         Raises
         ------
         TypeError
-            If ``init`` is not an `Initialization`.
+            If init is not an `Initialization`.
         ValueError
             If the node is already registered as an input node.
         """

--- a/graphqomb/noise_model.py
+++ b/graphqomb/noise_model.py
@@ -16,7 +16,7 @@ This module provides:
 - `noise_op_to_stim`: Conversion function.
 - `depolarize1_probs`: Utility to create single-qubit depolarizing probabilities.
 - `depolarize2_probs`: Utility to create 2-qubit depolarizing probabilities.
-- :data:`PAULI_CHANNEL_2_ORDER`: Constant for Pauli channel order.
+- `PAULI_CHANNEL_2_ORDER`: Constant for Pauli channel order.
 
 See Also
 --------
@@ -24,8 +24,8 @@ stim_compile : The main compilation function that accepts a NoiseModel.
 
 Notes
 -----
-- **Placement control**: Each `NoiseOp` has a ``placement`` attribute.
-  ``AUTO`` defers to :func:`default_noise_placement`, while
+- **Placement control**: Each `NoiseOp` has a placement attribute.
+  ``AUTO`` defers to `default_noise_placement`, while
   ``BEFORE``/``AFTER`` force insertion side.
 
 - **Record delta**: Heralded instructions (`HeraldedPauliChannel1`,
@@ -112,6 +112,8 @@ PAULI_CHANNEL_2_ORDER: tuple[str, ...] = (
     "ZY",
     "ZZ",
 )
+"""Canonical two-qubit Pauli pair order of Stim's ``PAULI_CHANNEL_2`` instruction."""
+
 _PAULI_CHANNEL_2_KEYS = frozenset(PAULI_CHANNEL_2_ORDER)
 _PAULI_CHANNEL_2_ARG_COUNT = len(PAULI_CHANNEL_2_ORDER)
 
@@ -134,7 +136,7 @@ def _validate_probability(name: str, value: float) -> float:
     Raises
     ------
     ValueError
-        If the probability is outside the range ``[0, 1]``.
+        If the probability is outside the range [0, 1].
     """
     p = float(value)
     if not 0.0 <= p <= 1.0:
@@ -153,7 +155,7 @@ def _validate_probability_sum(name: str, probabilities: Sequence[float], *, atol
     probabilities : `collections.abc.Sequence`\[`float`\]
         Probability values to validate.
     atol : `float`, optional
-        Absolute tolerance for sum comparison, by default ``1e-12``.
+        Absolute tolerance for sum comparison, by default 1e-12.
 
     Raises
     ------
@@ -184,7 +186,7 @@ def _validate_noise_placement(name: str, placement: NoisePlacement) -> NoisePlac
     Raises
     ------
     TypeError
-        If ``placement`` is not a `NoisePlacement`.
+        If placement is not a `NoisePlacement`.
     """
     if not isinstance(placement, NoisePlacement):
         msg = f"{name} must be a NoisePlacement, got {placement!r}"
@@ -375,7 +377,7 @@ class IdleEvent:
     nodes : `collections.abc.Sequence`\[`NodeInfo`\]
         Information about all nodes that are idle during this tick.
     duration : `float`
-        The duration of the idle period (from ``tick_duration`` parameter).
+        The duration of the idle period (from the tick_duration parameter).
     """
 
     time: int
@@ -427,7 +429,7 @@ class PauliChannel1:
         Target qubit indices.
     placement : `NoisePlacement`
         Whether to insert before or after the main operation.
-        ``AUTO`` defers to :func:`default_noise_placement`.
+        ``AUTO`` defers to `default_noise_placement`.
 
     Examples
     --------
@@ -472,7 +474,7 @@ class PauliChannel2:
         Target qubit pairs as ``((q0, q1), ...)``.
     placement : `NoisePlacement`
         Whether to insert before or after the main operation.
-        ``AUTO`` defers to :func:`default_noise_placement`.
+        ``AUTO`` defers to `default_noise_placement`.
 
     Examples
     --------
@@ -548,7 +550,7 @@ class HeraldedPauliChannel1:
 
     Similar to `PauliChannel1` but produces a herald measurement record
     indicating whether an error occurred. The herald outcome is 1 if any
-    error occurred (including identity with probability ``pi``).
+    error occurred (including identity with probability pi).
     Corresponds to Stim's ``HERALDED_PAULI_CHANNEL_1`` instruction.
 
     Parameters
@@ -565,7 +567,7 @@ class HeraldedPauliChannel1:
         Target qubit indices.
     placement : `NoisePlacement`
         Whether to insert before or after the main operation.
-        ``AUTO`` defers to :func:`default_noise_placement`.
+        ``AUTO`` defers to `default_noise_placement`.
 
     Notes
     -----
@@ -619,7 +621,7 @@ class HeraldedErase:
         Target qubit indices.
     placement : `NoisePlacement`
         Whether to insert before or after the main operation.
-        ``AUTO`` defers to :func:`default_noise_placement`.
+        ``AUTO`` defers to `default_noise_placement`.
 
     Notes
     -----
@@ -664,7 +666,7 @@ class RawStimOp:
         Most noise instructions do not add records (default 0).
     placement : `NoisePlacement`
         Whether to insert before or after the main operation.
-        ``AUTO`` defers to :func:`default_noise_placement`.
+        ``AUTO`` defers to `default_noise_placement`.
 
     Examples
     --------
@@ -833,13 +835,13 @@ def noise_op_to_stim(op: NoiseOp) -> tuple[str, int]:  # ruff:ignore[too-many-re
     -------
     `tuple`\[`str`, `int`\]
         A tuple of ``(stim_instruction, record_delta)`` where
-        ``stim_instruction`` is a single line of Stim code and
-        ``record_delta`` is the number of measurement records added.
+        stim_instruction is a single line of Stim code and
+        record_delta is the number of measurement records added.
 
     Raises
     ------
     TypeError
-        If ``op`` is not a recognized NoiseOp type.
+        If op is not a recognized NoiseOp type.
 
     Examples
     --------

--- a/graphqomb/pruning.py
+++ b/graphqomb/pruning.py
@@ -1,8 +1,14 @@
-"""Prune graph-state compile inputs before passing them to ``qompile``.
+"""Prune graph-state compile inputs before passing them to `qompile`.
 
-``prune_z_nodes`` removes eligible Z-basis nodes, while
-``prune_isolated_components`` removes components unrelated to outputs or
+`prune_z_nodes` removes eligible Z-basis nodes, while
+`prune_isolated_components` removes components unrelated to outputs or
 logical observables. Both update all compile inputs and preserve node indices.
+
+This module provides:
+
+- `PruneResult`: Pruned compile inputs and the removed nodes.
+- `prune_z_nodes`: Remove eligible Z-prepared and Z-measured nodes.
+- `prune_isolated_components`: Remove components unrelated to outputs or logical observables.
 """
 
 from __future__ import annotations
@@ -47,44 +53,44 @@ def prune_z_nodes(  # ruff:ignore[too-many-arguments]
     prune_measurements: bool = True,
     protected_preparation_tags: AbstractSet[str] | None = None,
 ) -> PruneResult:
-    """Remove eligible Z-prepared and Z-measured nodes from compile inputs.
+    r"""Remove eligible Z-prepared and Z-measured nodes from compile inputs.
 
     Output nodes are always kept. Preparation and measurement pruning can be
-    disabled independently, and ``protected_preparation_tags`` protects matching
+    disabled independently, and protected_preparation_tags protects matching
     Z-prepared inputs. A node both prepared and measured in Z is governed by
     the preparation controls.
 
     Parameters
     ----------
-    graph : BaseGraphState
+    graph : `BaseGraphState`
         Source graph state.
-    xflow : Mapping[int, AbstractSet[int]]
+    xflow : `collections.abc.Mapping`\[`int`, `collections.abc.Set`\[`int`\]\]
         X correction flow.
-    zflow : Mapping[int, AbstractSet[int]] | None
-        Z correction flow, derived from ``xflow`` when omitted.
-    parity_check_group : Sequence[AbstractSet[int]] | None
+    zflow : `collections.abc.Mapping`\[`int`, `collections.abc.Set`\[`int`\]\] | `None`
+        Z correction flow, derived from xflow when omitted.
+    parity_check_group : `collections.abc.Sequence`\[`collections.abc.Set`\[`int`\]\] | `None`
         Parity checks to update.
-    parity_check_tags : Sequence[str] | None
-        Tags aligned with ``parity_check_group``.
-    logical_observables : Mapping[int, AbstractSet[int]] | None
+    parity_check_tags : `collections.abc.Sequence`\[`str`\] | `None`
+        Tags aligned with parity_check_group.
+    logical_observables : `collections.abc.Mapping`\[`int`, `collections.abc.Set`\[`int`\]\] | `None`
         Logical-observable seed nodes to update.
-    prune_preparations : bool
+    prune_preparations : `bool`
         Whether to remove Z-prepared inputs.
-    prune_measurements : bool
+    prune_measurements : `bool`
         Whether to remove corrected Z measurements.
-    protected_preparation_tags : AbstractSet[str] | None
+    protected_preparation_tags : `collections.abc.Set`\[`str`\] | `None`
         Initialization tags that protect Z-prepared inputs.
 
     Returns
     -------
-    PruneResult
-        Pruned inputs suitable for ``qompile`` or further pruning.
+    `PruneResult`
+        Pruned inputs suitable for `qompile` or further pruning.
 
     Raises
     ------
     ValueError
-        If ``parity_check_tags`` is given but not aligned with
-        ``parity_check_group``.
+        If parity_check_tags is given but not aligned with
+        parity_check_group.
 
     Notes
     -----
@@ -129,7 +135,7 @@ def prune_isolated_components(  # ruff:ignore[too-many-arguments]
     parity_check_tags: Sequence[str] | None = None,
     logical_observables: Mapping[int, AbstractSet[int]] | None = None,
 ) -> PruneResult:
-    """Remove components unrelated to outputs or logical-observable seeds.
+    r"""Remove components unrelated to outputs or logical-observable seeds.
 
     Graph edges and correction-flow entries both connect nodes. With no output
     nodes or logical observables, every component is removed; this operation is
@@ -137,29 +143,29 @@ def prune_isolated_components(  # ruff:ignore[too-many-arguments]
 
     Parameters
     ----------
-    graph : BaseGraphState
+    graph : `BaseGraphState`
         Source graph state.
-    xflow : Mapping[int, AbstractSet[int]]
+    xflow : `collections.abc.Mapping`\[`int`, `collections.abc.Set`\[`int`\]\]
         X correction flow.
-    zflow : Mapping[int, AbstractSet[int]] | None
+    zflow : `collections.abc.Mapping`\[`int`, `collections.abc.Set`\[`int`\]\] | `None`
         Explicit Z correction flow, if any.
-    parity_check_group : Sequence[AbstractSet[int]] | None
+    parity_check_group : `collections.abc.Sequence`\[`collections.abc.Set`\[`int`\]\] | `None`
         Parity checks to update.
-    parity_check_tags : Sequence[str] | None
-        Tags aligned with ``parity_check_group``.
-    logical_observables : Mapping[int, AbstractSet[int]] | None
+    parity_check_tags : `collections.abc.Sequence`\[`str`\] | `None`
+        Tags aligned with parity_check_group.
+    logical_observables : `collections.abc.Mapping`\[`int`, `collections.abc.Set`\[`int`\]\] | `None`
         Logical-observable seeds that make components relevant.
 
     Returns
     -------
-    PruneResult
-        Pruned inputs suitable for ``qompile``.
+    `PruneResult`
+        Pruned inputs suitable for `qompile`.
 
     Raises
     ------
     ValueError
-        If ``parity_check_tags`` is given but not aligned with
-        ``parity_check_group``.
+        If parity_check_tags is given but not aligned with
+        parity_check_group.
     """  # ruff:ignore[docstring-extraneous-exception]
     relevant_nodes = set(graph.output_node_indices)
     if logical_observables is not None:

--- a/graphqomb/ptn_format.py
+++ b/graphqomb/ptn_format.py
@@ -524,32 +524,32 @@ def _parse_arrow_mapping(line: str, label: str) -> tuple[int, set[int]]:
 
 @dataclass(slots=True)
 class _PatternData:
-    """Container for parsed pattern data from .ptn format.
+    r"""Container for parsed pattern data from .ptn format.
 
     Attributes
     ----------
-    input_node_indices : `dict`[`int`, `int`]
+    input_node_indices : `dict`\[`int`, `int`\]
         Mapping from node to qubit index for input nodes.
-    output_node_indices : `dict`[`int`, `int`]
+    output_node_indices : `dict`\[`int`, `int`\]
         Mapping from node to qubit index for output nodes.
-    input_coordinates : `dict`[`int`, `tuple`[`float`, ...]]
+    input_coordinates : `dict`\[`int`, `tuple`\[`float`, ...\]\]
         Coordinates for input nodes.
-    input_initialization_axes : `dict`[`int`, `Axis`]
+    input_initialization_axes : `dict`\[`int`, `Axis`\]
         Pauli initialization axes for input nodes.
-    input_initialization_tags : `dict`[`int`, `str`]
+    input_initialization_tags : `dict`\[`int`, `str`\]
         Stim-style instruction tags of input initializations; the empty
         string means untagged.
-    commands : `list`[`Command`]
+    commands : `list`\[`Command`\]
         List of quantum commands.
-    xflow : `dict`[`int`, `set`[`int`]]
+    xflow : `dict`\[`int`, `set`\[`int`\]\]
         X correction flow mapping.
-    zflow : `dict`[`int`, `set`[`int`]]
+    zflow : `dict`\[`int`, `set`\[`int`\]\]
         Z correction flow mapping.
-    parity_check_groups : `list`[`set`[`int`]]
+    parity_check_groups : `list`\[`set`\[`int`\]\]
         Parity check groups for error detection.
-    parity_check_tags : `list`[`str`]
+    parity_check_tags : `list`\[`str`\]
         Stim-style tag of each parity check group, aligned with
-        ``parity_check_groups``; the empty string means untagged.
+        parity_check_groups; the empty string means untagged.
     """
 
     input_node_indices: dict[int, int] = field(default_factory=dict[int, int])

--- a/graphqomb/qeccode.py
+++ b/graphqomb/qeccode.py
@@ -1,4 +1,12 @@
-"""QEC Code object."""
+"""QEC Code object.
+
+This module provides:
+
+- `YFoliation`: Foliation variants for Y-support stabilizer measurement.
+- `StabilizerCode`: Dense-column stabilizer code container.
+- `StabilizerGraphStateBuildResult`: Result of building a graph state from a stabilizer code.
+- `build_graph_state`: Build a graph state from a stabilizer code.
+"""
 
 from __future__ import annotations
 
@@ -71,10 +79,10 @@ class StabilizerCode:
 class StabilizerGraphStateBuildResult(NamedTuple):
     """Result of building a graph state from a stabilizer code.
 
-    ``graph`` is the constructed graph state with data and ancilla nodes,
-    edges, coordinates, and measurement bases. ``data_nodes`` maps each
+    graph is the constructed graph state with data and ancilla nodes,
+    edges, coordinates, and measurement bases. data_nodes maps each
     ``(physical_qubit, data_layer)`` pair to its graph node id.
-    ``ancilla_nodes`` maps each stabilizer row index to its ancilla graph node
+    ancilla_nodes maps each stabilizer row index to its ancilla graph node
     id.
     """
 
@@ -120,7 +128,7 @@ def build_graph_state(
     z_base : `int`, optional
         Lower stabilizer-measurement data-layer index, by default 0. Type I
         uses two measurement layers; Type II uses three for Y support. When
-        ``data_as_io`` is enabled, a separate output layer is appended.
+        data_as_io is enabled, a separate output layer is appended.
     y_foliation : `YFoliation`, optional
         Foliation variant. Type I measures each stabilizer ancilla in X when
         its row has an even number of Y supports, including zero, and in Y
@@ -134,7 +142,7 @@ def build_graph_state(
         inputs and append separate unmeasured output nodes, by default False.
     qubit_indices : `collections.abc.Mapping`\[`int`, `int`\] | `None`, optional
         Mapping from stabilizer-code qubit columns to graph qindices when
-        ``data_as_io`` is enabled. If omitted, code qubit columns are used.
+        data_as_io is enabled. If omitted, code qubit columns are used.
 
     Returns
     -------
@@ -146,7 +154,7 @@ def build_graph_state(
     TypeError
         If z_base is not an integer.
     ValueError
-        If ``qubit_indices`` is invalid for the requested data I/O layout.
+        If qubit_indices is invalid for the requested data I/O layout.
     """
     if not isinstance(z_base, int):
         msg = "z_base must be an integer."
@@ -247,11 +255,11 @@ def _add_layered_data_nodes(
     code: StabilizerCode,
     data_layer_plan: _DataLayerPlan,
 ) -> dict[tuple[int, int], int]:
-    """Add layered data nodes.
+    r"""Add layered data nodes.
 
     Returns
     -------
-    `dict`[`tuple`[`int`, `int`], `int`]
+    `dict`\[`tuple`\[`int`, `int`\], `int`\]
         Mapping from physical qubit and z layer to graph node.
     """
     data_nodes: dict[tuple[int, int], int] = {}
@@ -285,11 +293,11 @@ def _add_ancilla_nodes(
     data_layer_plan: _DataLayerPlan,
     meas_basis: AxisMeasBasis,
 ) -> dict[int, int]:
-    """Add ancilla nodes and stabilizer-support edges.
+    r"""Add ancilla nodes and stabilizer-support edges.
 
     Returns
     -------
-    `dict`[`int`, `int`]
+    `dict`\[`int`, `int`\]
         Mapping from stabilizer row index to graph node.
     """
     ancilla_nodes: dict[int, int] = {}
@@ -337,14 +345,14 @@ def _twisted_stabilizer_pairs(
     *,
     count_equal_y: bool,
 ) -> list[tuple[int, int]]:
-    """Return stabilizer pairs whose ancillas require a CZ edge.
+    r"""Return stabilizer pairs whose ancillas require a CZ edge.
 
     Local interactions on each shared data qubit are ordered Z, Y, then X.
-    For a stabilizer pair, let ``forward`` and ``reverse`` be the numbers of
+    For a stabilizer pair, let forward and reverse be the numbers of
     shared qubits with the two possible strict orders. The number of twisted
     qubit pairs is ``forward * reverse``, so only the parity of each direction
     is required. Equal-X and equal-Z overlaps have no strict order and never
-    twist. An equal-Y overlap twists exactly when ``count_equal_y`` is set:
+    twist. An equal-Y overlap twists exactly when count_equal_y is set:
     under Type I foliation a Y factor couples the ancilla to both nodes of the
     data chain, so its Z-side and X-side components each cross the partner's
     opposite component, contributing to both direction parities at once. Under
@@ -356,7 +364,7 @@ def _twisted_stabilizer_pairs(
 
     Parameters
     ----------
-    supports : `Sequence`[`_StabilizerSupport`]
+    supports : `collections.abc.Sequence`\[`_StabilizerSupport`\]
         Per-stabilizer X/Z support sets.
     count_equal_y : `bool`
         Whether equal-Y overlaps contribute to both direction parities
@@ -364,7 +372,7 @@ def _twisted_stabilizer_pairs(
 
     Returns
     -------
-    `list`[`tuple`[`int`, `int`]]
+    `list`\[`tuple`\[`int`, `int`\]\]
         Sorted stabilizer-row pairs requiring an ancilla CZ edge.
     """
     incidences_by_qubit: dict[int, list[tuple[int, int]]] = defaultdict(list)
@@ -434,11 +442,11 @@ def _type_ii_support_layer(layers: tuple[int, ...], *, has_x: bool, has_z: bool)
 
 
 def _stabilizer_supports(code: StabilizerCode) -> list[_StabilizerSupport]:
-    """Return sparse X/Z support sets for every stabilizer row.
+    r"""Return sparse X/Z support sets for every stabilizer row.
 
     Returns
     -------
-    `list`[`_StabilizerSupport`]
+    `list`\[`_StabilizerSupport`\]
         Support sets indexed by stabilizer row.
     """
     hx = code.hx.copy()
@@ -462,11 +470,11 @@ def _qubits_with_y_support(code: StabilizerCode) -> set[int]:
 
 
 def _data_coordinate(code: StabilizerCode, qubit: int, z: float) -> tuple[float, float, float] | None:
-    """Return the 3D coordinate of a layered data node.
+    r"""Return the 3D coordinate of a layered data node.
 
     Returns
     -------
-    `tuple`[`float`, `float`, `float`] | `None`
+    `tuple`\[`float`, `float`, `float`\] | `None`
         Lifted 3D coordinate, or None when the qubit has no coordinate.
     """
     if code.qubit_coord is None or qubit not in code.qubit_coord:
@@ -476,11 +484,11 @@ def _data_coordinate(code: StabilizerCode, qubit: int, z: float) -> tuple[float,
 
 
 def _explicit_ancilla_coordinate(code: StabilizerCode, stabilizer: int) -> tuple[float, float, float] | None:
-    """Return an explicitly supplied ancilla coordinate, if present.
+    r"""Return an explicitly supplied ancilla coordinate, if present.
 
     Returns
     -------
-    `tuple`[`float`, `float`, `float`] | `None`
+    `tuple`\[`float`, `float`, `float`\] | `None`
         Explicit 3D coordinate, or None when no coordinate is supplied.
     """
     if code.stabilizer_coord is None or stabilizer not in code.stabilizer_coord:
@@ -490,11 +498,11 @@ def _explicit_ancilla_coordinate(code: StabilizerCode, stabilizer: int) -> tuple
 
 
 def _row_support(matrix: csr_array, row: int) -> list[int]:
-    """Return nonzero column indices in a CSR sparse row.
+    r"""Return nonzero column indices in a CSR sparse row.
 
     Returns
     -------
-    `list`[`int`]
+    `list`\[`int`\]
         Nonzero column indices for the row.
     """
     start = int(matrix.indptr[row])
@@ -503,11 +511,11 @@ def _row_support(matrix: csr_array, row: int) -> list[int]:
 
 
 def _average_node_coordinates(graph: GraphState, nodes: list[int]) -> tuple[float, float, float] | None:
-    """Return the componentwise average of node coordinates when all are available.
+    r"""Return the componentwise average of node coordinates when all are available.
 
     Returns
     -------
-    `tuple`[`float`, `float`, `float`] | `None`
+    `tuple`\[`float`, `float`, `float`\] | `None`
         Average coordinate, or None when no average can be inferred.
     """
     if not nodes:
@@ -527,7 +535,7 @@ def _avoid_occupied_coordinate(
     graph: GraphState,
     coordinate: tuple[float, float, float],
 ) -> tuple[float, float, float]:
-    """Move an inferred ancilla coordinate aside when its centroid is occupied.
+    r"""Move an inferred ancilla coordinate aside when its centroid is occupied.
 
     The temporal coordinate is preserved. Candidate positions expand
     deterministically in the data plane until one has enough clearance from
@@ -535,7 +543,7 @@ def _avoid_occupied_coordinate(
 
     Returns
     -------
-    `tuple`[`float`, `float`, `float`]
+    `tuple`\[`float`, `float`, `float`\]
         The original coordinate when unoccupied, otherwise a nearby free one.
 
     Raises

--- a/graphqomb/qompiler.py
+++ b/graphqomb/qompiler.py
@@ -52,7 +52,7 @@ def qompile(  # ruff:ignore[too-many-arguments]
     logical_observables : `collections.abc.Mapping`\[`int`, `collections.abc.Set`\[`int`\]\] | `None`
         logical observables represented by logical index and seed nodes
     parity_check_tags : `collections.abc.Sequence`\[`str`\] | `None`
-        Stim-style tag per parity check group, aligned with ``parity_check_group``.
+        Stim-style tag per parity check group, aligned with parity_check_group.
         The tag ``type=flag`` marks a flag detector whose firing samples are
         meant to be post-selected. If `None`, every group is untagged.
     scheduler : `Scheduler` | `None`, optional

--- a/graphqomb/rng.py
+++ b/graphqomb/rng.py
@@ -21,7 +21,7 @@ def ensure_rng(rng: Generator | None = None) -> Generator:
 
     Parameters
     ----------
-    rng : `numpy.random.Generator` | None, optional
+    rng : `numpy.random.Generator` | `None`, optional
         The random-number generator to use, by default None
 
     Returns

--- a/graphqomb/scheduler/core.py
+++ b/graphqomb/scheduler/core.py
@@ -229,8 +229,8 @@ class Scheduler:
 
         The graph is treated as undirected. For convenience, `entangle_time` accepts edges
         in either order: both ``(u, v)`` and ``(v, u)`` are recognized. If both keys are
-        provided, the canonical order (as returned by :attr:`BaseGraphState.edges`)
-        takes precedence, even when the value is ``None``.
+        provided, the canonical order (as returned by `BaseGraphState.edges`)
+        takes precedence, even when the value is `None`.
         """
         self.prepare_time = {
             node: prepare_time.get(node, None) for node in self.graph.nodes - self.graph.input_node_indices.keys()

--- a/graphqomb/simulator.py
+++ b/graphqomb/simulator.py
@@ -259,7 +259,7 @@ class PatternSimulator:
 
         Parameters
         ----------
-        rng : `numpy.random.Generator` | None, optional
+        rng : `numpy.random.Generator` | `None`, optional
             Random number generator to use for measurement outcomes.
             If None, a new generator will be created using the default random source. Default is None.
 

--- a/graphqomb/statevec.py
+++ b/graphqomb/statevec.py
@@ -135,7 +135,7 @@ class StateVector(BaseFullStateSimulator):
 
         Parameters
         ----------
-        states : sequence of array-like
+        states : `collections.abc.Sequence`\[`numpy.typing.ArrayLike`\]
             One-qubit state vectors in external qubit order.
 
         Returns

--- a/graphqomb/stim_glue/_parse.py
+++ b/graphqomb/stim_glue/_parse.py
@@ -38,18 +38,18 @@ class StimMppExtraction:
 
     Attributes
     ----------
-    code : StabilizerCode
+    code : `StabilizerCode`
         Dense-column stabilizer code using the ``[Hx | Hz]`` convention.
     stim_to_column : `dict`\[`int`, `int`\]
         Mapping from the Stim qubit ids of the analyzed circuit to dense matrix
         columns. When the circuit importer splits a mid-circuit reset onto a
         fresh wire, the id is that of the measured reset lifetime rather than
-        the original circuit id; ``StimImportResult.wire_to_stim`` maps it back.
+        the original circuit id; `StimImportResult.wire_to_stim` maps it back.
     column_to_stim : `dict`\[`int`, `int`\]
         Inverse dense-column mapping.
     supports : `tuple`\[``PauliSupport``, ...\]
         Stim Pauli supports, one support per stabilizer row, over the same ids
-        as ``stim_to_column``.
+        as stim_to_column.
     detector_rows : `tuple`\[`frozenset`\[`int`\], ...\]
         Detector groups as selected-MPP stabilizer row indices.
     logical_observable_rows : `dict`\[`int`, `frozenset`\[`int`\]\]
@@ -59,9 +59,9 @@ class StimMppExtraction:
     logical_observable_record_indices : `dict`\[`int`, `frozenset`\[`int`\]\]
         Absolute Stim record indices for selected logical observables.
     detector_tags : `tuple`\[`str`, ...\]
-        Stim tag of each selected detector, aligned with ``detector_rows``.
+        Stim tag of each selected detector, aligned with detector_rows.
         The empty string means untagged; ``type=flag`` marks a post-selection
-        flag detector. Suitable as the ``parity_check_tags`` argument of
+        flag detector. Suitable as the parity_check_tags argument of
         `graphqomb.qompiler.qompile` next to `detector_groups`.
     """
 
@@ -76,17 +76,17 @@ class StimMppExtraction:
     detector_tags: tuple[str, ...] = ()
 
     def detector_groups(self, ancilla_nodes: Mapping[int, int]) -> list[set[int]]:
-        r"""Return detector groups mapped to graph node ids for ``qompile``.
+        r"""Return detector groups mapped to graph node ids for `qompile`.
 
         Returns
         -------
         `list`\[`set`\[`int`\]\]
-            Detector groups suitable for ``qompile``.
+            Detector groups suitable for `qompile`.
         """
         return [_map_rows_to_nodes(rows, ancilla_nodes, "detector") for rows in self.detector_rows]
 
     def logical_observables(self, ancilla_nodes: Mapping[int, int]) -> dict[int, set[int]]:
-        r"""Return logical observables mapped to graph node ids for ``qompile``.
+        r"""Return logical observables mapped to graph node ids for `qompile`.
 
         Returns
         -------
@@ -118,8 +118,8 @@ def stim_mpp_extraction_from_records(  # ruff:ignore[too-many-arguments]
     Raises
     ------
     ValueError
-        If the support and record counts differ, or if ``detector_tags`` is
-        not aligned with ``detector_record_indices``.
+        If the support and record counts differ, or if detector_tags is
+        not aligned with detector_record_indices.
     """
     if len(supports) != len(record_indices):
         msg = "MPP support count does not match its measurement-record count."
@@ -196,7 +196,7 @@ class RecordAnnotations:
     detectors : `tuple`\[`frozenset`\[`int`\], ...\]
         One absolute record-index group per ``DETECTOR``, in circuit order.
     detector_tags : `tuple`\[`str`, ...\]
-        Stim tag of each ``DETECTOR``, aligned with ``detectors``. The empty
+        Stim tag of each ``DETECTOR``, aligned with detectors. The empty
         string means untagged; ``type=flag`` marks a post-selection flag
         detector.
     logical_observables : `dict`\[`int`, `frozenset`\[`int`\]\]
@@ -262,7 +262,7 @@ def extract_qubit_coordinates(
     *,
     coord_dims: int,
 ) -> dict[int, Coordinate]:
-    """Return final Stim qubit coordinates projected to ``coord_dims``.
+    """Return final Stim qubit coordinates projected to coord_dims.
 
     Returns
     -------
@@ -440,7 +440,7 @@ def plain_qubit_target(target: stim.GateTarget, instruction_name: str) -> int:
     """Return a plain Stim qubit target.
 
     Rejects Pauli-typed and inverted-result targets, which the importer cannot
-    represent. ``mpp_rewriter._plain_qubit`` deliberately accepts those
+    represent. `mpp_rewriter._plain_qubit` deliberately accepts those
     because it only needs the qubit id an instruction acts on.
 
     Returns

--- a/graphqomb/stim_glue/importer.py
+++ b/graphqomb/stim_glue/importer.py
@@ -1,4 +1,12 @@
-"""Import supported Stim circuits into GraphQOMB patterns."""
+"""Import supported Stim circuits into GraphQOMB patterns.
+
+This module provides:
+
+- `StimImportResult`: Result of importing a supported Stim circuit.
+- `stim_file_to_pattern`: Import a supported Stim file into a GraphQOMB pattern.
+- `stim_text_to_pattern`: Import supported Stim text into a GraphQOMB pattern.
+- `stim_circuit_to_pattern`: Import a supported Stim circuit into a GraphQOMB pattern.
+"""
 
 from __future__ import annotations
 
@@ -60,25 +68,25 @@ _CONTROLLED_PAULI_GATES = frozenset(name for name, _position in _FEEDBACK_AXES)
 class StimImportResult:
     r"""Result of importing a supported Stim circuit.
 
-    ``stim_to_qubit`` maps each Stim qubit id to the qubit index of its
+    stim_to_qubit maps each Stim qubit id to the qubit index of its
     initial (input-side) wire. When a Stim qubit is used again after a direct
     single-qubit measurement or re-initialized by a mid-circuit reset, the
     importer issues a fresh internal qubit index for the new wire;
-    ``qubit_to_stim`` maps every internal qubit index, including those
+    qubit_to_stim maps every internal qubit index, including those
     continuation indices, back to its Stim qubit id. That mapping is
-    many-to-one, so ``stim_to_final_qubit`` names the index of the last
+    many-to-one, so stim_to_final_qubit names the index of the last
     lifetime of each Stim qubit; the earlier indices of a reset qubit are its
     discarded history, whose wires may remain pattern outputs.
 
     A mid-circuit reset also issues a fresh *Stim* qubit id for the reset
-    lifetime, and that id is what ``mpp_extractions`` reports in ``supports``,
-    ``stim_to_column``, and ``column_to_stim``. ``wire_to_stim`` maps every
+    lifetime, and that id is what mpp_extractions reports in supports,
+    stim_to_column, and column_to_stim. wire_to_stim maps every
     such id back to the original circuit's Stim qubit id; it is the identity
     on qubits that are never reset mid-circuit.
 
     Attributes
     ----------
-    pattern : Pattern
+    pattern : `Pattern`
         Imported measurement pattern.
     stim_to_qubit : `dict`\[`int`, `int`\]
         Original Stim qubit id to the internal qubit index of its initial wire.
@@ -200,9 +208,9 @@ def stim_file_to_pattern(  # ruff:ignore[too-many-arguments]
 ) -> StimImportResult:
     """Import a supported Stim file into a GraphQOMB pattern.
 
-    When ``merge_safe_ticks`` is true, TICK boundaries whose removal cannot
+    When merge_safe_ticks is true, TICK boundaries whose removal cannot
     change the imported semantics are dropped before import; see
-    `stim_circuit_to_pattern`. ``schedule_config`` and ``schedule_timeout``
+    `stim_circuit_to_pattern`. schedule_config and schedule_timeout
     select the pattern-level scheduler; see `stim_circuit_to_pattern`.
 
     Returns
@@ -233,9 +241,9 @@ def stim_text_to_pattern(  # ruff:ignore[too-many-arguments]
 ) -> StimImportResult:
     """Import supported Stim text into a GraphQOMB pattern.
 
-    When ``merge_safe_ticks`` is true, TICK boundaries whose removal cannot
+    When merge_safe_ticks is true, TICK boundaries whose removal cannot
     change the imported semantics are dropped before import; see
-    `stim_circuit_to_pattern`. ``schedule_config`` and ``schedule_timeout``
+    `stim_circuit_to_pattern`. schedule_config and schedule_timeout
     select the pattern-level scheduler; see `stim_circuit_to_pattern`.
 
     Returns
@@ -266,11 +274,11 @@ def stim_circuit_to_pattern(  # ruff:ignore[too-many-locals, too-many-arguments]
 ) -> StimImportResult:
     """Import a supported Stim circuit into a GraphQOMB pattern.
 
-    ``schedule_config`` controls how the imported pattern is scheduled: when
+    schedule_config controls how the imported pattern is scheduled: when
     given, a `graphqomb.scheduler.core.Scheduler` is built from the imported
-    graph and flows, solved with that configuration (``schedule_timeout``
+    graph and flows, solved with that configuration (schedule_timeout
     bounds the CP-SAT solve time in seconds), and passed to
-    `graphqomb.qompiler.qompile`; when `None`, ``qompile`` schedules with its
+    `graphqomb.qompiler.qompile`; when `None`, `qompile` schedules with its
     default greedy strategy.
 
     The importer supports initial Pauli resets, Clifford unitary blocks, and
@@ -318,12 +326,12 @@ def stim_circuit_to_pattern(  # ruff:ignore[too-many-locals, too-many-arguments]
     reset remains a pattern output; leaving it coherent and untouched is
     channel-equivalent to Stim's trace-out reset on every recorded
     measurement, provided that discarded output is traced out rather than read.
-    ``qubit_to_stim`` maps the fresh indices back to the original Stim qubit
-    id, and ``stim_to_final_qubit`` selects the live one among them.
+    qubit_to_stim maps the fresh indices back to the original Stim qubit
+    id, and stim_to_final_qubit selects the live one among them.
 
     ``DETECTOR`` instruction tags are preserved: each imported detector's tag
-    is carried into ``pattern.pauli_frame.parity_check_tags`` (aligned with
-    ``parity_check_group``) and re-emitted by
+    is carried into pattern.pauli_frame.parity_check_tags (aligned with
+    parity_check_group) and re-emitted by
     `graphqomb.stim_glue.compiler.stim_compile`, so post-selection flag
     detectors (``DETECTOR[type=flag]``) survive the import/export round trip.
 
@@ -331,7 +339,7 @@ def stim_circuit_to_pattern(  # ruff:ignore[too-many-locals, too-many-arguments]
     are never cancelled against each other or folded into an adjacent
     reset or measurement, so a finely ticked circuit can import to a much
     larger graph than the same instructions in fewer blocks. When
-    ``merge_safe_ticks`` is true, the importer drops every TICK whose removal
+    merge_safe_ticks is true, the importer drops every TICK whose removal
     cannot change the imported semantics before analyzing the circuit. Because
     per-qubit instruction order and measurement-record order survive block
     normalization, the only TICKs kept are those separating two blocks that
@@ -341,10 +349,10 @@ def stim_circuit_to_pattern(  # ruff:ignore[too-many-locals, too-many-arguments]
     out z-compressed because merged blocks share layers.
 
     Each reset lifetime also gets its own Stim qubit id internally, and the
-    ``mpp_extractions`` metadata (``supports``, ``stim_to_column``, and
-    ``column_to_stim``) reports the lifetime that an ``MPP`` product actually
+    mpp_extractions metadata (supports, stim_to_column, and
+    column_to_stim) reports the lifetime that an ``MPP`` product actually
     measured, so a qubit measured before and after a reset occupies a distinct
-    column in each block. ``wire_to_stim`` maps those ids back to the original
+    column in each block. wire_to_stim maps those ids back to the original
     circuit ids.
 
     Returns
@@ -356,7 +364,7 @@ def stim_circuit_to_pattern(  # ruff:ignore[too-many-locals, too-many-arguments]
     ------
     ValueError
         If the circuit uses unsupported instructions or invalid coordinates,
-        or if ``schedule_config`` is given and no schedule is found.
+        or if schedule_config is given and no schedule is found.
     """
     if coord_dims not in {2, 3}:
         msg = "coord_dims must be 2 or 3."
@@ -1284,7 +1292,7 @@ def _reuse_fragment(  # ruff:ignore[too-many-arguments]
 
     Each reused measurement binds an internal measured node onto the qubit's
     current wire end and opens a continuation wire on a freshly issued qubit
-    index. The continuation node reuses the qubit's XY coordinates at ``z``
+    index. The continuation node reuses the qubit's XY coordinates at z
     and is initialized in the positive eigenstate of the measurement axis.
     After a plain measurement the correction flows condition the continuation
     on the outcome; after a measure-reset gate the re-prepared eigenstate is
@@ -1407,7 +1415,7 @@ def _new_wire_fragment(
 ) -> _Fragment:
     """Open fresh wires for reset-started lifetimes at their reset position.
 
-    Each wire reuses its original qubit's XY coordinates at ``z`` and is
+    Each wire reuses its original qubit's XY coordinates at z and is
     initialized in the positive eigenstate of its last leading reset axis.
     The reset discards the previous state, so the wire carries no outcome
     conditioning; the replaced wire simply ends (a measured wire ended at its

--- a/graphqomb/stim_glue/mpp.py
+++ b/graphqomb/stim_glue/mpp.py
@@ -1,4 +1,10 @@
-"""Build stabilizer-code inputs from Stim MPP layers."""
+"""Build stabilizer-code inputs from Stim MPP layers.
+
+This module provides:
+
+- `stabilizer_code_from_stim_file`: Build a `StabilizerCode` from a Stim file.
+- `stabilizer_code_from_stim_text`: Build a `StabilizerCode` from Stim circuit text.
+"""
 
 from __future__ import annotations
 
@@ -37,7 +43,7 @@ def stabilizer_code_from_stim_file(
     """Build a stabilizer code from MPP products in a Stim file.
 
     Signed MPP products are not supported. A Stim target inversion such as
-    ``!X0`` raises ``ValueError`` because stabilizer signs are not retained.
+    ``!X0`` raises `ValueError` because stabilizer signs are not retained.
 
     Returns
     -------
@@ -64,7 +70,7 @@ def stabilizer_code_from_stim_text(
     ``Hx``; ``Z`` and ``Y`` targets set entries in ``Hz``. By default,
     ``mpp_layer=0`` selects the first contiguous MPP layer. Pass
     ``mpp_layer=None`` to select all MPP products in the flattened Stim file.
-    Signed MPP products are not supported because ``StabilizerCode`` does not
+    Signed MPP products are not supported because `StabilizerCode` does not
     retain stabilizer signs. A Stim target inversion such as ``!X0`` is
     therefore rejected instead of being silently discarded.
 

--- a/graphqomb/stim_glue/mpp_rewriter.py
+++ b/graphqomb/stim_glue/mpp_rewriter.py
@@ -177,7 +177,7 @@ def rewrite_to_mpp(circuit: stim.Circuit | str, *, fallback: _FallbackMode = "ci
 
     The inference conjugates each final measurement Pauli backwards through the
     segment's Clifford body (``U† P U`` via ``stim.PauliString.before``) and
-    substitutes ``+1`` for stabilizers of freshly initialized, measured-out
+    substitutes +1 for stabilizers of freshly initialized, measured-out
     ancillas. A segment ends when a unitary follows its measurements, or when a
     measurement follows a reset issued after those measurements (including the
     implicit reset of ``MR``); trailing data measurements therefore start a
@@ -230,7 +230,7 @@ def rewrite_to_mpp(circuit: stim.Circuit | str, *, fallback: _FallbackMode = "ci
     Raises
     ------
     ValueError
-        If ``fallback`` is not ``"circuit"`` or ``"segment"``.
+        If fallback is not ``"circuit"`` or ``"segment"``.
     """
     if fallback not in {"circuit", "segment"}:
         msg = f"fallback must be 'circuit' or 'segment', not {fallback!r}."
@@ -364,7 +364,7 @@ def _instruction_kind(instruction: stim.CircuitInstruction) -> _InstructionKind:
 def _plain_qubit(target: stim.GateTarget, instruction_name: str) -> int:
     """Return the Stim qubit id a target acts on.
 
-    Unlike ``_parse.plain_qubit_target``, Pauli-typed and inverted-result
+    Unlike `_parse.plain_qubit_target`, Pauli-typed and inverted-result
     targets are accepted: the rewriter only needs the qubit id here, and it
     reports unsupported targets as `UnsupportedSyndromeCircuitError`.
 
@@ -1021,7 +1021,7 @@ def _remap_tableau_circuit(tableau: stim.Tableau, qubits: Sequence[int]) -> stim
     Returns
     -------
     ``stim.Circuit``
-        Synthesized Clifford circuit on ``qubits``.
+        Synthesized Clifford circuit on qubits.
 
     Raises
     ------
@@ -1049,7 +1049,7 @@ def _matched_flow_output_pairs(
     Returns
     -------
     `list`\[`tuple`\[``stim.PauliString``, ``stim.PauliString``\]\]
-        Converted/original output-Pauli pairs restricted to ``qubits``.
+        Converted/original output-Pauli pairs restricted to qubits.
 
     Raises
     ------

--- a/graphqomb/stim_glue/postselect.py
+++ b/graphqomb/stim_glue/postselect.py
@@ -55,8 +55,8 @@ def flag_detector_indices(circuit: stim.Circuit) -> tuple[int, ...]:
 def flag_postselection_mask(circuit: stim.Circuit) -> npt.NDArray[np.uint8]:
     r"""Return a bit-packed post-selection mask over the flag detectors of a circuit.
 
-    Detector ``k`` is marked when bit ``mask[k // 8] & (1 << (k % 8))`` is
-    set, matching the ``postselection_mask`` argument of ``sinter.Task``:
+    Detector k is marked when bit ``mask[k // 8] & (1 << (k % 8))`` is
+    set, matching the postselection_mask argument of ``sinter.Task``:
     samples in which a marked detector fires are discarded.
 
     Returns

--- a/graphqomb/stim_glue/transpiler.py
+++ b/graphqomb/stim_glue/transpiler.py
@@ -1,4 +1,12 @@
-"""Transpile Stim Clifford circuits into GraphQOMB's Clifford J/CZ basis."""
+"""Transpile Stim Clifford circuits into GraphQOMB's Clifford J/CZ basis.
+
+This module provides:
+
+- `UnsupportedInstructionError`: Error for instructions outside the supported gate set.
+- `transpile`: Transpile a Stim Clifford circuit into the Clifford J/CZ gate basis.
+- `optimize_j_cz`: Remove redundant Clifford J and CZ gates.
+- `STIM_GATE_J_ANGLES`: Map of Stim gate names to Clifford J angles.
+"""
 
 from __future__ import annotations
 
@@ -17,15 +25,18 @@ if TYPE_CHECKING:
 HS_STIM_GATE = "C_XNYZ"
 HZ_STIM_GATE = "SQRT_Y"
 HS_DAG_STIM_GATE = "C_XYZ"
-# Maps each single-qubit basis gate, by its Stim spelling, to the angle of the
-# one J(angle) = H Rz(angle) primitive implementing it. These are the four
-# Clifford XY-plane measurements: X+ (H), Y+ (HS), X- (HZ), and Y- (HS_DAG).
 STIM_GATE_J_ANGLES: dict[str, float] = {
     "H": 0.0,
     HS_STIM_GATE: math.pi / 2,
     HZ_STIM_GATE: math.pi,
     HS_DAG_STIM_GATE: -math.pi / 2,
 }
+"""Map of each single-qubit basis gate, by its Stim spelling, to the angle of the
+one ``J(angle) = H Rz(angle)`` primitive implementing it.
+
+These are the four Clifford XY-plane measurements: X+ (``H``), Y+ (``HS``),
+X- (``HZ``), and Y- (``HS_DAG``).
+"""
 _PauliAxis = Literal["X", "Y", "Z"]
 _LOCAL_BASIS_GENERATORS = ("H", HS_STIM_GATE, HZ_STIM_GATE, HS_DAG_STIM_GATE)
 _LOCAL_BASIS_GATES = frozenset(_LOCAL_BASIS_GENERATORS)
@@ -61,7 +72,7 @@ def transpile(
     optimize: bool = False,
     preserved_measurement_qubits: AbstractSet[int] = frozenset(),
 ) -> stim.Circuit:
-    """Transpile a Stim Clifford circuit into the Clifford J/CZ gate basis.
+    r"""Transpile a Stim Clifford circuit into the Clifford J/CZ gate basis.
 
     The single-qubit basis gates are the four Clifford ``J(angle)`` gates,
     i.e. the XY-plane Pauli measurements: ``H = J(0)`` (X+),
@@ -79,7 +90,7 @@ def transpile(
     optimize : `bool`, optional
         Remove redundant basis gates and simplify gates adjacent to
         R/RX/RY and M/MX/MY boundaries after transpilation.
-    preserved_measurement_qubits : ``collections.abc.Set[int]``, optional
+    preserved_measurement_qubits : `collections.abc.Set`\[`int`\], optional
         Qubits whose post-measurement state must survive the optimized
         circuit. Measurements on these qubits are never folded into a
         rewritten Pauli basis, so single-qubit gates ahead of them stay
@@ -102,7 +113,7 @@ def optimize_j_cz(
     *,
     preserved_measurement_qubits: AbstractSet[int] = frozenset(),
 ) -> stim.Circuit:
-    """Remove redundant Clifford J and CZ gates.
+    r"""Remove redundant Clifford J and CZ gates.
 
     Every maximal run of single-qubit basis gates on one qubit is replaced by
     the shortest word over the four Clifford J gates (``H``, ``HS``, ``HZ``,
@@ -119,7 +130,7 @@ def optimize_j_cz(
     ----------
     circuit : ``stim.Circuit`` | `str`
         A circuit in the Clifford J/CZ basis.
-    preserved_measurement_qubits : ``collections.abc.Set[int]``, optional
+    preserved_measurement_qubits : `collections.abc.Set`\[`int`\], optional
         Qubits whose post-measurement state must survive the optimized
         circuit. Measurements on these qubits are never folded into a
         rewritten Pauli basis.

--- a/graphqomb/visualizer.py
+++ b/graphqomb/visualizer.py
@@ -78,7 +78,7 @@ def visualize(  # ruff:ignore[too-many-arguments]
     ----------
     graph : `BaseGraphState`
         GraphState to visualize.
-    ax : `matplotlib.axes.Axes` | None, optional
+    ax : `matplotlib.axes.Axes` | `None`, optional
         Matplotlib Axes to draw on, by default None
     show_node_labels : `bool`, optional
         Whether to show node index labels, by default True
@@ -182,16 +182,16 @@ def visualize(  # ruff:ignore[too-many-arguments]
 
 
 def _setup_figure(node_pos: Mapping[int, tuple[float, float]]) -> FigureSetup:
-    """Calculate figure dimensions and plot limits based on node positions.
+    r"""Calculate figure dimensions and plot limits based on node positions.
 
     Parameters
     ----------
-    node_pos : collections.abc.Mapping[int, tuple[float, float]]
+    node_pos : `collections.abc.Mapping`\[`int`, `tuple`\[`float`, `float`\]\]
         Dictionary mapping node indices to (x, y) positions
 
     Returns
     -------
-    FigureSetup
+    `FigureSetup`
         NamedTuple containing
         x_min, x_max, y_min, y_max, padding, fig_width, fig_height values
     """
@@ -241,18 +241,18 @@ def _determine_node_positions(
     graph: BaseGraphState,
     use_graph_coordinates: bool,
 ) -> dict[int, tuple[float, float]]:
-    """Get node positions, using graph coordinates if available and requested.
+    r"""Get node positions, using graph coordinates if available and requested.
 
     Parameters
     ----------
-    graph : BaseGraphState
+    graph : `BaseGraphState`
         GraphState to visualize.
-    use_graph_coordinates : bool
+    use_graph_coordinates : `bool`
         Whether to use coordinates stored in the graph.
 
     Returns
     -------
-    dict[int, tuple[float, float]]
+    `dict`\[`int`, `tuple`\[`float`, `float`\]\]
         Mapping of node indices to their (x, y) positions.
     """
     if use_graph_coordinates and graph.coordinates:
@@ -278,16 +278,16 @@ def _determine_node_positions(
 
 
 def _calc_node_positions(graph: BaseGraphState) -> dict[int, tuple[float, float]]:
-    """Calculate node positions for visualization with input/output nodes arranged vertically.
+    r"""Calculate node positions for visualization with input/output nodes arranged vertically.
 
     Parameters
     ----------
-    graph : BaseGraphState
+    graph : `BaseGraphState`
         GraphState to visualize.
 
     Returns
     -------
-    dict[int, tuple[float, float]]
+    `dict`\[`int`, `tuple`\[`float`, `float`\]\]
         Mapping of node indices to their (x, y) positions.
     """
     internal_nodes = graph.nodes - graph.input_node_indices.keys() - graph.output_node_indices.keys()
@@ -354,11 +354,11 @@ def _determine_node_colors(graph: BaseGraphState) -> dict[int, ColorMap]:
 
 
 def _find_pauli_nodes(graph: BaseGraphState) -> dict[int, Axis]:
-    """Identify nodes with Pauli measurements (Clifford angles).
+    r"""Identify nodes with Pauli measurements (Clifford angles).
 
     Returns
     -------
-    dict[int, Axis]
+    `dict`\[`int`, `Axis`\]
         Dictionary mapping node indices to Pauli axis
     """
     pauli_nodes: dict[int, Axis] = {}
@@ -380,18 +380,18 @@ def _scatter_size_to_patch_radius(ax: Axes, x: float, y: float, scatter_size: fl
 
     Parameters
     ----------
-    ax : Axes
+    ax : `matplotlib.axes.Axes`
         Matplotlib axes object
-    x : float
+    x : `float`
         X position of the node in data coordinates
-    y : float
+    y : `float`
         Y position of the node in data coordinates
-    scatter_size : float
+    scatter_size : `float`
         Scatter plot size parameter (area in points²)
 
     Returns
     -------
-    float
+    `float`
         Equivalent radius in data coordinates for patches
     """
     # Convert scatter size (points²) to radius in points
@@ -424,12 +424,12 @@ def _calculate_font_size(node_size: float) -> int:
 
     Parameters
     ----------
-    node_size : float
+    node_size : `float`
         Node size parameter (scatter size in points^2)
 
     Returns
     -------
-    int
+    `int`
         Font size for node labels that fit within the node
     """
     # Calculate the diameter of the node in points
@@ -445,17 +445,17 @@ def _calculate_font_size(node_size: float) -> int:
 
 
 def _draw_pauli_node(ax: Axes, pos: tuple[float, float], pauli_axis: Axis, node_radius: float) -> None:
-    """Draw a Pauli measurement node with hatch patterns.
+    r"""Draw a Pauli measurement node with hatch patterns.
 
     Parameters
     ----------
-    ax : Axes
+    ax : `matplotlib.axes.Axes`
         Matplotlib axes object
-    pos : tuple[float, float]
+    pos : `tuple`\[`float`, `float`\]
         Node position (x, y)
-    pauli_axis : Axis
+    pauli_axis : `Axis`
         Pauli axis
-    node_radius : float
+    node_radius : `float`
         Radius for the node patches
     """
     x, y = pos
@@ -501,9 +501,9 @@ def _add_legend(ax: Axes, graph: BaseGraphState) -> None:
 
     Parameters
     ----------
-    ax : Axes
+    ax : `matplotlib.axes.Axes`
         Matplotlib axes object to add legend to
-    graph : BaseGraphState
+    graph : `BaseGraphState`
         GraphState to analyze for legend items
     """
     planes_present, pauli_measurements = _analyze_graph_measurements(graph)
@@ -515,16 +515,16 @@ def _add_legend(ax: Axes, graph: BaseGraphState) -> None:
 
 
 def _analyze_graph_measurements(graph: BaseGraphState) -> tuple[set[Plane], set[Axis]]:
-    """Analyze graph measurements to determine legend content.
+    r"""Analyze graph measurements to determine legend content.
 
     Parameters
     ----------
-    graph : BaseGraphState
+    graph : `BaseGraphState`
         GraphState to analyze
 
     Returns
     -------
-    tuple[set[Plane], set[Axis]]
+    `tuple`\[`set`\[`Plane`\], `set`\[`Axis`\]\]
         Tuple of (planes_present, pauli_measurements)
     """
     planes_present: set[Plane] = set()
@@ -544,20 +544,20 @@ def _analyze_graph_measurements(graph: BaseGraphState) -> tuple[set[Plane], set[
 def _create_legend_elements(
     graph: BaseGraphState, planes_present: AbstractSet[Plane], pauli_measurements: AbstractSet[Axis]
 ) -> list[Line2D | patches.Circle]:
-    """Create legend elements for the plot.
+    r"""Create legend elements for the plot.
 
     Parameters
     ----------
-    graph : BaseGraphState
+    graph : `BaseGraphState`
         GraphState object
-    planes_present : collections.abc.Set[Plane]
+    planes_present : `collections.abc.Set`\[`Plane`\]
         Set of measurement planes present in graph
-    pauli_measurements : collections.abc.Set[Axis]
+    pauli_measurements : `collections.abc.Set`\[`Axis`\]
         Set of Pauli measurement axes present in graph
 
     Returns
     -------
-    list[Line2D | patches.Circle]
+    `list`\[`matplotlib.lines.Line2D` | `matplotlib.patches.Circle`\]
         List of matplotlib legend elements (Line2D and Circle patches)
     """
     legend_elements: list[Line2D | patches.Circle] = []

--- a/graphqomb/zx_util.py
+++ b/graphqomb/zx_util.py
@@ -102,7 +102,7 @@ def _require_pyzx() -> PyZXModule:
 
     Returns
     -------
-    PyZXModule
+    `PyZXModule`
         Imported `pyzx` module.
 
     Raises
@@ -133,13 +133,13 @@ class VertexData:
     ----------
     vertex_id : `int`
         Original PyZX vertex id.
-    vertex_type : VertexType
+    vertex_type : ``VertexType``
         PyZX vertex type.
-    phase : FractionLike
+    phase : ``FractionLike``
         PyZX vertex phase in multiples of pi.
-    qubit : FloatInt
+    qubit : ``FloatInt``
         PyZX qubit coordinate.
-    row : FloatInt
+    row : ``FloatInt``
         PyZX row coordinate.
     is_ground : `bool`
         Whether the vertex is marked as ground in PyZX.
@@ -163,7 +163,7 @@ class EdgeData:
         Smaller endpoint id of the undirected edge.
     target : `int`
         Larger endpoint id of the undirected edge.
-    edge_type : EdgeType
+    edge_type : ``EdgeType``
         PyZX edge type.
     """
 
@@ -232,7 +232,7 @@ def _collect_import_data(diagram: PyZXDiagram, *, recognize_pg: bool) -> _PyZXIm
 
     Returns
     -------
-    _PyZXImportData
+    `_PyZXImportData`
         Topology, boundary registration, measurement bases, and coordinates
         used to initialize the imported `GraphState`.
     """
@@ -268,11 +268,11 @@ def _collect_import_data(diagram: PyZXDiagram, *, recognize_pg: bool) -> _PyZXIm
 
 
 def _validate_no_ground_vertices(node_map: Mapping[int, VertexData]) -> None:
-    """Reject PyZX diagrams containing ground vertices.
+    r"""Reject PyZX diagrams containing ground vertices.
 
     Parameters
     ----------
-    node_map : collections.abc.Mapping[int, VertexData]
+    node_map : `collections.abc.Mapping`\[`int`, `VertexData`\]
         Imported PyZX vertex metadata keyed by vertex id.
 
     Raises
@@ -296,16 +296,16 @@ def _build_meas_basis_map(
 
     Parameters
     ----------
-    node_map : collections.abc.Mapping[int, VertexData]
+    node_map : `collections.abc.Mapping`\[`int`, `VertexData`\]
         Imported PyZX vertex metadata keyed by vertex id.
-    output_nodes : collections.abc.Set[int]
+    output_nodes : `collections.abc.Set`\[`int`\]
         Node ids that should be treated as outputs and skipped.
-    excluded_nodes : collections.abc.Set[int] | None, optional
+    excluded_nodes : `collections.abc.Set`\[`int`\] | `None`, optional
         Non-output nodes to exclude from default measurement-basis collection.
 
     Returns
     -------
-    dict[int, PlannerMeasBasis]
+    `dict`\[`int`, `PlannerMeasBasis`\]
         Measurement-basis assignments for imported nodes.
 
     Raises
@@ -343,12 +343,12 @@ def _build_coordinate_map(node_map: Mapping[int, VertexData]) -> dict[int, tuple
 
     Parameters
     ----------
-    node_map : collections.abc.Mapping[int, VertexData]
+    node_map : `collections.abc.Mapping`\[`int`, `VertexData`\]
         Imported PyZX vertex metadata keyed by vertex id.
 
     Returns
     -------
-    dict[int, tuple[float, float]]
+    `dict`\[`int`, `tuple`\[`float`, `float`\]\]
         Coordinate map keyed by PyZX vertex id.
     """
     return {
@@ -361,12 +361,12 @@ def _phase_to_angle(phase: FractionLike) -> float:
 
     Parameters
     ----------
-    phase : FractionLike
+    phase : ``FractionLike``
         PyZX phase value expressed in multiples of pi.
 
     Returns
     -------
-    float
+    `float`
         Phase angle in radians.
 
     Raises
@@ -384,16 +384,16 @@ def _phase_to_angle(phase: FractionLike) -> float:
 def _collect_node_map(
     diagram: PyZXDiagram,
 ) -> dict[int, VertexData]:
-    """Collect vertex metadata from a PyZX diagram.
+    r"""Collect vertex metadata from a PyZX diagram.
 
     Parameters
     ----------
-    diagram : PyZXDiagram
+    diagram : `PyZXDiagram`
         Input PyZX diagram.
 
     Returns
     -------
-    dict[int, VertexData]
+    `dict`\[`int`, `VertexData`\]
         Vertex metadata keyed by PyZX vertex id.
     """
     node_map: dict[int, VertexData] = {}
@@ -414,16 +414,16 @@ def _collect_node_map(
 def _collect_edge_map(
     diagram: PyZXDiagram,
 ) -> dict[tuple[int, int], EdgeData]:
-    """Collect edge metadata from a PyZX diagram.
+    r"""Collect edge metadata from a PyZX diagram.
 
     Parameters
     ----------
-    diagram : PyZXDiagram
+    diagram : `PyZXDiagram`
         Input PyZX diagram.
 
     Returns
     -------
-    dict[tuple[int, int], EdgeData]
+    `dict`\[`tuple`\[`int`, `int`\], `EdgeData`\]
         Edge metadata keyed by canonical undirected endpoint pairs.
 
     Raises
@@ -451,18 +451,18 @@ def _collect_edge_map(
 
 
 def _edge_key(source: int, target: int) -> tuple[int, int]:
-    """Return a canonical key for an undirected edge.
+    r"""Return a canonical key for an undirected edge.
 
     Parameters
     ----------
-    source : int
+    source : `int`
         One endpoint of the edge.
-    target : int
+    target : `int`
         The other endpoint of the edge.
 
     Returns
     -------
-    tuple[int, int]
+    `tuple`\[`int`, `int`\]
         Edge endpoints ordered increasingly.
     """
     return (source, target) if source <= target else (target, source)
@@ -477,16 +477,16 @@ def _rewrite_input_boundary_maps(
 
     Parameters
     ----------
-    diagram : PyZXDiagram
+    diagram : `PyZXDiagram`
         Input PyZX diagram.
-    node_map : collections.abc.MutableMapping[int, VertexData]
+    node_map : `collections.abc.MutableMapping`\[`int`, `VertexData`\]
         Mutable imported vertex metadata keyed by vertex id.
-    edge_map : collections.abc.MutableMapping[tuple[int, int], EdgeData]
+    edge_map : `collections.abc.MutableMapping`\[`tuple`\[`int`, `int`\], `EdgeData`\]
         Mutable imported edge metadata keyed by canonical endpoint pairs.
 
     Returns
     -------
-    tuple[int, ...]
+    `tuple`\[`int`, ...\]
         Imported input nodes in logical-qubit order.
 
     Raises
@@ -552,16 +552,16 @@ def _rewrite_output_boundary_maps(
 
     Parameters
     ----------
-    diagram : PyZXDiagram
+    diagram : `PyZXDiagram`
         Input PyZX diagram.
-    node_map : collections.abc.MutableMapping[int, VertexData]
+    node_map : `collections.abc.MutableMapping`\[`int`, `VertexData`\]
         Mutable imported vertex metadata keyed by vertex id.
-    edge_map : collections.abc.MutableMapping[tuple[int, int], EdgeData]
+    edge_map : `collections.abc.MutableMapping`\[`tuple`\[`int`, `int`\], `EdgeData`\]
         Mutable imported edge metadata keyed by canonical endpoint pairs.
 
     Returns
     -------
-    tuple[int, ...]
+    `tuple`\[`int`, ...\]
         Imported output nodes in logical-qubit order.
 
     Raises
@@ -649,16 +649,16 @@ def _collect_phase_gadget_meas_bases(
 
     Parameters
     ----------
-    diagram : PyZXDiagram
+    diagram : `PyZXDiagram`
         Input PyZX diagram.
-    node_map : collections.abc.MutableMapping[int, VertexData]
+    node_map : `collections.abc.MutableMapping`\[`int`, `VertexData`\]
         Mutable imported vertex metadata keyed by vertex id.
-    edge_map : collections.abc.MutableMapping[tuple[int, int], EdgeData]
+    edge_map : `collections.abc.MutableMapping`\[`tuple`\[`int`, `int`\], `EdgeData`\]
         Mutable imported edge metadata keyed by canonical endpoint pairs.
 
     Returns
     -------
-    dict[int, PlannerMeasBasis]
+    `dict`\[`int`, `PlannerMeasBasis`\]
         Measurement-basis overrides for recognized phase-gadget neighbors.
     """
     candidates: list[tuple[int, int]] = []
@@ -706,7 +706,7 @@ def _phase_gadget_neighbor(
 
     Returns
     -------
-    int | None
+    `int` | `None`
         Neighbor vertex id when the lone spider matches a supported
         phase-gadget pattern, otherwise `None`.
     """


### PR DESCRIPTION
**Context (if applicable):**

The early core modules (`common`, `graphstate`, `pattern`, `qompiler`, ...) follow a consistent docstring style, but modules added or edited in recent commits drifted from it: bare or unescaped type lines, Sphinx roles (`:func:`/`:data:`/`:attr:`), and double backquotes around Python identifiers where the original style uses single backquotes.

**Description of the change:**

Docstring-only cleanup (plus two constant docstrings) restoring the original conventions across the package:

- Type lines in Parameters/Attributes/Returns sections use single-backquoted types with escaped brackets and qualified paths, e.g. `` `collections.abc.Mapping`\[`int`, `collections.abc.Set`\[`int`\]\] ``, replacing bare (`xflow : Mapping[int, AbstractSet[int]]`) and unescaped-bracket (`` `dict`[`int`, `int`] ``) type lines. This also covers `visualizer.py` and `zx_util.py`, which predate the current history but never matched the dominant style.
- References to Python objects (classes, functions, `None`) use single backquotes instead of double backquotes or Sphinx roles; the docs build resolves them through `default_role = "any"` as before.
- Parameter and attribute names mentioned in prose are plain text, matching the early modules.
- Double backquotes remain only for literal non-identifier text: Stim program text (``MPP``, ``DETECTOR[type=flag]``), `.ptn` format tokens, expressions, string literals, and third-party types with no intersphinx inventory (``stim.Circuit``, pyzx types).
- Modules missing the "This module provides:" list gained one (`pruning`, `qeccode`, `stim_glue` importer/transpiler/mpp).
- `PAULI_CHANNEL_2_ORDER` and `STIM_GATE_J_ANGLES` gained data docstrings so their module-list references resolve under the `any` role (the pattern `FLAG_DETECTOR_TAG` already uses).

Verified locally: `ruff check`/`ruff format --check`, `mypy`, `pytest` (1122 passed), and `sphinx-build -W` compared against a `main` baseline build — the only warning differences are intersphinx targets (`int`, `None`, `collections.abc.*`) that fail locally solely because the sandbox cannot fetch the inventories; they resolve on CI.

**Related issue:**

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYctJATgLcH8peFidieq6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYctJATgLcH8peFidieq6p)_