### PR TITLE
Release GraphQOMB 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-08-14
+
 ### Added
 
 - **Compile-input pruning**: The new `graphqomb.pruning` module offers `prune_z_nodes`, which removes Z-prepared inputs and byproduct-corrected Z-measured nodes from a graph state and drops them from the correction flows, parity check groups, and logical observables in one pass (a Z-measured node whose byproduct is not corrected by the flows is kept), and `prune_isolated_components`, which deletes components touching neither an output node nor a logical observable seed (e.g. fragments left behind by Z pruning), where graph edges and correction-flow entries both count as connections. Preparation and measurement pruning toggle independently via `prune_preparations`/`prune_measurements`, `prune_uncorrected_measurements` also removes Z-measured nodes whose byproducts the flows do not correct (fixing the branch without a Z byproduct on their neighbors, for simulations whose results do not depend on those outcomes), and `protected_preparation_tags` protects Z-prepared inputs by their initialization tag. Pruning is sign-aware: a node measured in an inverted Z basis (angle π) fixes record 1 in the kept branch, which fires the corrections the node sources, so such a node — including a Z-prepared input — is removed only when those corrections are vacuous. Both return a `PruneResult` that preserves node indices and feeds directly into `qompile`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graphqomb"
-version = "0.5.2"
+version = "0.5.3"
 description = "A modular Graph State qompiler for measurement-based quantum computing."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -704,7 +704,7 @@ wheels = [
 
 [[package]]
 name = "graphqomb"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary

- Cut the existing unreleased changelog entries as GraphQOMB 0.5.3, dated 2026-08-14.
- Bump the project and lockfile package metadata from 0.5.2 to 0.5.3.

## Impact

This prepares the 0.5.3 release containing the new compile-input pruning module (`prune_z_nodes` / `prune_isolated_components`), initialization tags surviving the stim round trip, and scheduler passthrough on stim import, plus the breaking `register_input(init=...)` / scheduler-subpackage / greedy-default changes merged since 0.5.2. The release PR itself changes only release metadata.

## Validation

- `uv lock --check`
- Installed package metadata reports `graphqomb==0.5.3`
- `uv run --extra stim pytest -q` — 1147 passed
- `uv run --with build==1.5.0 python -m build --installer uv` — sdist and wheel built successfully
- Built sdist and wheel metadata report `graphqomb==0.5.3`
- `git diff --check origin/main...HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)